### PR TITLE
Add nightly homebrew workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,85 @@
+name: nightly
+
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  update-homebrew-nightly:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update nightly formula in homebrew-tap
+        env:
+          COMMITTER_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          COMMIT_SHA="${GITHUB_SHA}"
+          SHORT_SHA="${COMMIT_SHA:0:7}"
+          DATE=$(date -u +%Y%m%d)
+          VERSION="nightly-${DATE}-${SHORT_SHA}"
+          ARCHIVE_URL="https://github.com/${{ github.repository }}/archive/${COMMIT_SHA}.tar.gz"
+
+          SHA256=$(curl -sL "${ARCHIVE_URL}" | sha256sum | cut -d' ' -f1)
+
+          FORMULA_CONTENT=$(cat <<RUBY
+          # This formula is automatically updated on every push to master. DO NOT EDIT.
+
+          class SqueezeNightly < Formula
+            desc "Extract rich information from any text (URIs, codetags, etc.) - nightly"
+            homepage "https://github.com/aymericbeaumet/squeeze"
+            url "${ARCHIVE_URL}"
+            version "${VERSION}"
+            sha256 "${SHA256}"
+            license "MIT"
+
+            depends_on "rust" => :build
+
+            conflicts_with "squeeze", because: "squeeze-nightly and squeeze install the same binary"
+
+            def install
+              system "cargo", "install", *std_cargo_args(path: "squeeze-cli")
+            end
+
+            test do
+              output = pipe_output("\#{bin}/squeeze --url", "visit https://example.com today")
+              assert_equal "https://example.com", output.strip
+            end
+          end
+          RUBY
+          )
+
+          # Remove leading whitespace from heredoc
+          FORMULA_CONTENT=$(echo "$FORMULA_CONTENT" | sed 's/^          //')
+
+          ENCODED_CONTENT=$(echo "$FORMULA_CONTENT" | base64 -w 0)
+
+          # Check if the file already exists to get its SHA (required for updates)
+          RESPONSE=$(curl -sf \
+            -H "Authorization: token ${COMMITTER_TOKEN}" \
+            "https://api.github.com/repos/aymericbeaumet/homebrew-tap/contents/Formula/squeeze-nightly.rb" || echo '{}')
+          FILE_SHA=$(echo "$RESPONSE" | jq -r '.sha // empty')
+
+          # Build the request body
+          if [ -n "$FILE_SHA" ]; then
+            BODY=$(jq -n \
+              --arg message "squeeze-nightly ${VERSION}" \
+              --arg content "$ENCODED_CONTENT" \
+              --arg sha "$FILE_SHA" \
+              '{message: $message, content: $content, sha: $sha}')
+          else
+            BODY=$(jq -n \
+              --arg message "squeeze-nightly ${VERSION}" \
+              --arg content "$ENCODED_CONTENT" \
+              '{message: $message, content: $content}')
+          fi
+
+          curl -sf -X PUT \
+            -H "Authorization: token ${COMMITTER_TOKEN}" \
+            -H "Content-Type: application/json" \
+            "https://api.github.com/repos/aymericbeaumet/homebrew-tap/contents/Formula/squeeze-nightly.rb" \
+            -d "$BODY"

--- a/Formula/squeeze.rb
+++ b/Formula/squeeze.rb
@@ -11,6 +11,8 @@ class Squeeze < Formula
 
   depends_on "rust" => :build
 
+  conflicts_with "squeeze-nightly", because: "squeeze-nightly and squeeze install the same binary"
+
   def install
     system "cargo", "install", *std_cargo_args(path: "squeeze-cli")
   end


### PR DESCRIPTION
## Summary
- Adds a `nightly.yml` workflow that pushes a `squeeze-nightly` formula to the homebrew-tap on every push to master
- Each nightly gets a unique version like `nightly-20260517-abc1234` with the correct archive URL and SHA256
- Adds `conflicts_with "squeeze-nightly"` to the stable formula (and vice versa) since both install the same `squeeze` binary

## How it works
- `brew install aymericbeaumet/tap/squeeze` — stable, tagged releases (updated by `release.yml`)
- `brew install aymericbeaumet/tap/squeeze-nightly` — latest master (updated by `nightly.yml`)

## Prerequisites
- `HOMEBREW_TAP_TOKEN` secret must be set (a GitHub PAT with `repo` scope)

## Test plan
- [ ] Set `HOMEBREW_TAP_TOKEN` secret: `gh auth token | gh secret set HOMEBREW_TAP_TOKEN`
- [ ] Merge this PR to trigger the nightly workflow
- [ ] Verify `squeeze-nightly.rb` appears in homebrew-tap
- [ ] `brew install aymericbeaumet/tap/squeeze-nightly` works
- [ ] Tag v0.1.0 to trigger the release workflow
- [ ] Verify `squeeze.rb` gets updated with correct SHA256 in homebrew-tap
- [ ] `brew install aymericbeaumet/tap/squeeze` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)