### PR TITLE
Add 14 new finders and fix nightly version

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -42,6 +42,7 @@ jobs:
             conflicts_with "squeeze", because: "squeeze-nightly and squeeze install the same binary"
 
             def install
+              ENV["SQUEEZE_VERSION"] = version.to_s
               system "cargo", "install", *std_cargo_args(path: "squeeze-cli")
             end
 

--- a/readme.md
+++ b/readme.md
@@ -5,8 +5,24 @@ information from any text (raw, JSON, HTML, YAML, etc).
 
 Currently supported:
 
-- Codetags (as defined per [PEP 350](https://www.python.org/dev/peps/pep-0350/))
-- URIs/URLs/URNs (as defined per [RFC 3986](https://tools.ietf.org/html/rfc3986/))
+| Finder | Flag | Examples |
+|--------|------|----------|
+| CIDR | `--cidr` | `192.168.1.0/24`, `2001:db8::/32` |
+| Codetags | `--codetag`, `--todo`, `--fixme` | `TODO: fix this`, `FIXME(#42): bug` |
+| Colors | `--color` | `#ff0000`, `rgb(255, 0, 0)`, `hsl(0, 100%, 50%)` |
+| Datetimes | `--datetime` | `2024-01-15`, `2024-01-15T10:30:00Z` |
+| Emails | `--email` | `user@example.com`, `first.last+tag@company.co.uk` |
+| Env vars | `--env` | `$HOME`, `${PATH}` |
+| Hashes | `--hash`, `--md5`, `--sha256` | `5d41402abc4b2a76b9719d911017c592` |
+| IPs | `--ip`, `--ipv4`, `--ipv6` | `192.168.1.1`, `::1`, `2001:db8::1` |
+| JSON | `--json` | `{"key": "value"}`, `[1, 2, 3]` |
+| JWTs | `--jwt` | `eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOi...` |
+| MACs | `--mac` | `00:1A:2B:3C:4D:5E`, `001A.2B3C.4D5E` |
+| Paths | `--path` | `/etc/hosts`, `./src/main.rs:42:10` |
+| Phones | `--phone` | `+14155551234`, `(415) 555-1234` |
+| Semver | `--semver` | `1.0.0`, `v2.3.1-rc.1+build.42` |
+| URIs | `--uri`, `--url`, `--http`, `--https` | `https://example.com`, `ftp://host/file` |
+| UUIDs | `--uuid` | `550e8400-e29b-41d4-a716-446655440000` |
 
 See [integrations](#integrations) for some practical uses. Continue reading for
 the install and getting started instructions.
@@ -66,46 +82,37 @@ https://aymericbeaumet.com
 https://wikipedia.com
 ```
 
-It is also possible to extract other types of information, like codetags
-(`TODO:`, `FIXME:`, etc). The usage remains very similar:
+Extract other types of information the same way:
 
 ```shell
-squeeze --codetag=todo << EOF
-// TODO: implement the main function
-fn main {}
-EOF
+echo '2024-01-15T10:30:00Z server at 192.168.1.0/24' | squeeze --datetime --cidr
 ```
 
 ```
-TODO: implement the main function
+2024-01-15T10:30:00Z
+192.168.1.0/24
 ```
 
-> Note that for convenience some aliases are defined. In this case, you can use
-`--todo` instead of `--codetag=todo`. In the same vein, `--url` is an alias to
-limit the search to specific URI schemes.
-
-It is possible to enable several finders at the same time, they will be run
-sequentially for each line:
+Enable several finders at the same time:
 
 ```shell
-squeeze --uri=http,https --codetag=todo,fixme << EOF
-// TODO: update with a better example
-// FIXME: all of https://github.com/aymericbeaumet/squeeze/issues
-// Some random comment to be ignored
-ftp://localhost
+squeeze --url --email --todo << EOF
+// TODO: email alice@example.com about https://example.com
 http://localhost
 EOF
 ```
 
 ```
-TODO: update with a better example
-FIXME: all of https://github.com/aymericbeaumet/squeeze/issues
-https://github.com/aymericbeaumet/squeeze/issues
+TODO: email alice@example.com about https://example.com
+alice@example.com
+https://example.com
 http://localhost
 ```
 
-This getting started should give you an overview of what's possible with
-`squeeze`. Have a look at all the possibilities with `squeeze --help`.
+Some finders support sub-filters. For example `--codetag=todo` or its alias
+`--todo`, `--uri=https`, `--hash=sha256`, etc.
+
+See all the possibilities with `squeeze --help`.
 
 ## Integrations
 
@@ -133,11 +140,12 @@ bind -T copy-mode-vi enter send -X copy-pipe-and-cancel "squeeze -1 --url --open
 
 ### shell (bash, zsh)
 
-Define a `urls` function to list all the URLs in your shell history:
+Define convenience functions:
 
 ```shell
 # ~/.bashrc ~/.zshrc
 urls() { fc -rl 1 | squeeze --url | sort -u; }
+ips() { squeeze --ip; }
 ```
 
 ## Development

--- a/squeeze-cli/main.rs
+++ b/squeeze-cli/main.rs
@@ -1,7 +1,8 @@
 use clap::Parser;
 use squeeze::{
-    codetag::Codetag, color::Color, email::Email, env::Env, hash::Hash, ip::Ip, json::Json,
-    mirror::Mirror, path::Path, phone::Phone, semver::Semver, uri::URI, uuid::Uuid, Finder,
+    cidr::Cidr, codetag::Codetag, color::Color, datetime::Datetime, email::Email, env::Env,
+    hash::Hash, ip::Ip, json::Json, jwt::Jwt, mac::Mac, mirror::Mirror, path::Path, phone::Phone,
+    semver::Semver, uri::URI, uuid::Uuid, Finder,
 };
 use std::convert::{TryFrom, TryInto};
 use std::io::{self, BufRead};
@@ -26,6 +27,10 @@ struct Opts {
     #[arg(long = "open", help = "open the results")]
     open: bool,
 
+    // cidr
+    #[arg(long = "cidr", help = "search for CIDR notation")]
+    cidr: bool,
+
     // codetag
     #[arg(long = "codetag", help = "search for codetags")]
     mnemonic: Option<Option<String>>,
@@ -42,6 +47,10 @@ struct Opts {
     // color
     #[arg(long = "color", help = "search for colors")]
     color: bool,
+
+    // datetime
+    #[arg(long = "datetime", help = "search for datetimes")]
+    datetime: bool,
 
     // email
     #[arg(long = "email", help = "search for email addresses")]
@@ -74,6 +83,14 @@ struct Opts {
     // json
     #[arg(long = "json", help = "search for JSON objects and arrays")]
     json: bool,
+
+    // jwt
+    #[arg(long = "jwt", help = "search for JSON Web Tokens")]
+    jwt: bool,
+
+    // mac
+    #[arg(long = "mac", help = "search for MAC addresses")]
+    mac: bool,
 
     // mirror
     #[arg(long = "mirror", help = "[debug] mirror the input")]
@@ -114,6 +131,18 @@ struct Opts {
     uuid: bool,
 }
 
+impl TryFrom<&Opts> for Cidr {
+    type Error = ();
+
+    fn try_from(opts: &Opts) -> Result<Self, Self::Error> {
+        if !opts.cidr {
+            return Err(());
+        }
+
+        Ok(Cidr::default())
+    }
+}
+
 impl TryFrom<&Opts> for Color {
     type Error = ();
 
@@ -123,6 +152,18 @@ impl TryFrom<&Opts> for Color {
         }
 
         Ok(Color::default())
+    }
+}
+
+impl TryFrom<&Opts> for Datetime {
+    type Error = ();
+
+    fn try_from(opts: &Opts) -> Result<Self, Self::Error> {
+        if !opts.datetime {
+            return Err(());
+        }
+
+        Ok(Datetime::default())
     }
 }
 
@@ -204,6 +245,30 @@ impl TryFrom<&Opts> for Json {
         }
 
         Ok(Json::default())
+    }
+}
+
+impl TryFrom<&Opts> for Jwt {
+    type Error = ();
+
+    fn try_from(opts: &Opts) -> Result<Self, Self::Error> {
+        if !opts.jwt {
+            return Err(());
+        }
+
+        Ok(Jwt::default())
+    }
+}
+
+impl TryFrom<&Opts> for Mac {
+    type Error = ();
+
+    fn try_from(opts: &Opts) -> Result<Self, Self::Error> {
+        if !opts.mac {
+            return Err(());
+        }
+
+        Ok(Mac::default())
     }
 }
 
@@ -335,13 +400,17 @@ fn main() -> ExitCode {
     env_logger::init();
 
     let opts = Opts::parse();
+    let cidr = TryInto::<Cidr>::try_into(&opts);
     let codetag = TryInto::<Codetag>::try_into(&opts);
     let color = TryInto::<Color>::try_into(&opts);
+    let datetime = TryInto::<Datetime>::try_into(&opts);
     let email = TryInto::<Email>::try_into(&opts);
     let env = TryInto::<Env>::try_into(&opts);
     let hash = TryInto::<Hash>::try_into(&opts);
     let ip = TryInto::<Ip>::try_into(&opts);
     let json = TryInto::<Json>::try_into(&opts);
+    let jwt = TryInto::<Jwt>::try_into(&opts);
+    let mac = TryInto::<Mac>::try_into(&opts);
     let mirror = TryInto::<Mirror>::try_into(&opts);
     let path = TryInto::<Path>::try_into(&opts);
     let phone = TryInto::<Phone>::try_into(&opts);
@@ -350,13 +419,17 @@ fn main() -> ExitCode {
     let uuid = TryInto::<Uuid>::try_into(&opts);
 
     let finders: Vec<_> = [
+        cidr.as_ref().map(|f| f as &dyn Finder),
         codetag.as_ref().map(|f| f as &dyn Finder),
         color.as_ref().map(|f| f as &dyn Finder),
+        datetime.as_ref().map(|f| f as &dyn Finder),
         email.as_ref().map(|f| f as &dyn Finder),
         env.as_ref().map(|f| f as &dyn Finder),
         hash.as_ref().map(|f| f as &dyn Finder),
         ip.as_ref().map(|f| f as &dyn Finder),
         json.as_ref().map(|f| f as &dyn Finder),
+        jwt.as_ref().map(|f| f as &dyn Finder),
+        mac.as_ref().map(|f| f as &dyn Finder),
         mirror.as_ref().map(|f| f as &dyn Finder),
         path.as_ref().map(|f| f as &dyn Finder),
         phone.as_ref().map(|f| f as &dyn Finder),

--- a/squeeze-cli/main.rs
+++ b/squeeze-cli/main.rs
@@ -1,13 +1,18 @@
 use clap::Parser;
-use squeeze::{codetag::Codetag, mirror::Mirror, uri::URI, Finder};
+use squeeze::{codetag::Codetag, email::Email, mirror::Mirror, path::Path, uri::URI, Finder};
 use std::convert::{TryFrom, TryInto};
 use std::io::{self, BufRead};
 use std::process::ExitCode;
 
+const VERSION: &str = match option_env!("SQUEEZE_VERSION") {
+    Some(v) => v,
+    None => env!("CARGO_PKG_VERSION"),
+};
+
 #[derive(Parser)]
 #[command(
     name = "squeeze",
-    version = env!("CARGO_PKG_VERSION"),
+    version = VERSION,
     author = "Aymeric Beaumet <hi@aymericbeaumet.com>",
     about = "Extract rich information from any text"
 )]
@@ -17,6 +22,10 @@ struct Opts {
     first: bool,
     #[arg(long = "open", help = "open the results")]
     open: bool,
+
+    // email
+    #[arg(long = "email", help = "search for email addresses")]
+    email: bool,
 
     // codetag
     #[arg(long = "codetag", help = "search for codetags")]
@@ -35,6 +44,10 @@ struct Opts {
     #[arg(long = "mirror", help = "[debug] mirror the input")]
     mirror: bool,
 
+    // path
+    #[arg(long = "path", help = "search for file paths")]
+    path: bool,
+
     // uri
     #[arg(long = "uri", help = "search for uris")]
     scheme: Option<Option<String>>,
@@ -52,6 +65,18 @@ struct Opts {
     http: bool,
     #[arg(long = "https", help = "alias for: --uri=https")]
     https: bool,
+}
+
+impl TryFrom<&Opts> for Email {
+    type Error = ();
+
+    fn try_from(opts: &Opts) -> Result<Self, Self::Error> {
+        if !opts.email {
+            return Err(());
+        }
+
+        Ok(Email::default())
+    }
 }
 
 impl TryFrom<&Opts> for Codetag {
@@ -90,8 +115,19 @@ impl TryFrom<&Opts> for Mirror {
             return Err(());
         }
 
-        let finder = Mirror::default();
-        Ok(finder)
+        Ok(Mirror::default())
+    }
+}
+
+impl TryFrom<&Opts> for Path {
+    type Error = ();
+
+    fn try_from(opts: &Opts) -> Result<Self, Self::Error> {
+        if !opts.path {
+            return Err(());
+        }
+
+        Ok(Path::default())
     }
 }
 
@@ -136,12 +172,16 @@ fn main() -> ExitCode {
 
     let opts = Opts::parse();
     let codetag = TryInto::<Codetag>::try_into(&opts);
+    let email = TryInto::<Email>::try_into(&opts);
     let mirror = TryInto::<Mirror>::try_into(&opts);
+    let path = TryInto::<Path>::try_into(&opts);
     let uri = TryInto::<URI>::try_into(&opts);
 
     let finders: Vec<_> = [
         codetag.as_ref().map(|f| f as &dyn Finder),
+        email.as_ref().map(|f| f as &dyn Finder),
         mirror.as_ref().map(|f| f as &dyn Finder),
+        path.as_ref().map(|f| f as &dyn Finder),
         uri.as_ref().map(|f| f as &dyn Finder),
     ]
     .into_iter()

--- a/squeeze-cli/main.rs
+++ b/squeeze-cli/main.rs
@@ -1,5 +1,8 @@
 use clap::Parser;
-use squeeze::{codetag::Codetag, email::Email, mirror::Mirror, path::Path, uri::URI, Finder};
+use squeeze::{
+    codetag::Codetag, color::Color, email::Email, env::Env, hash::Hash, ip::Ip, json::Json,
+    mirror::Mirror, path::Path, phone::Phone, semver::Semver, uri::URI, uuid::Uuid, Finder,
+};
 use std::convert::{TryFrom, TryInto};
 use std::io::{self, BufRead};
 use std::process::ExitCode;
@@ -23,10 +26,6 @@ struct Opts {
     #[arg(long = "open", help = "open the results")]
     open: bool,
 
-    // email
-    #[arg(long = "email", help = "search for email addresses")]
-    email: bool,
-
     // codetag
     #[arg(long = "codetag", help = "search for codetags")]
     mnemonic: Option<Option<String>>,
@@ -40,6 +39,42 @@ struct Opts {
     #[arg(long = "todo", help = "alias for: --codetag=todo")]
     todo: bool,
 
+    // color
+    #[arg(long = "color", help = "search for colors")]
+    color: bool,
+
+    // email
+    #[arg(long = "email", help = "search for email addresses")]
+    email: bool,
+
+    // env
+    #[arg(long = "env", help = "search for environment variables")]
+    env: bool,
+
+    // hash
+    #[arg(long = "hash", help = "search for hashes")]
+    hash_algo: Option<Option<String>>,
+    #[arg(long = "md5", help = "alias for: --hash=md5")]
+    md5: bool,
+    #[arg(long = "sha1", help = "alias for: --hash=sha1")]
+    sha1: bool,
+    #[arg(long = "sha256", help = "alias for: --hash=sha256")]
+    sha256: bool,
+    #[arg(long = "sha512", help = "alias for: --hash=sha512")]
+    sha512: bool,
+
+    // ip
+    #[arg(long = "ip", help = "search for IP addresses")]
+    ip: bool,
+    #[arg(long = "ipv4", help = "search for IPv4 addresses")]
+    ipv4: bool,
+    #[arg(long = "ipv6", help = "search for IPv6 addresses")]
+    ipv6: bool,
+
+    // json
+    #[arg(long = "json", help = "search for JSON objects and arrays")]
+    json: bool,
+
     // mirror
     #[arg(long = "mirror", help = "[debug] mirror the input")]
     mirror: bool,
@@ -47,6 +82,14 @@ struct Opts {
     // path
     #[arg(long = "path", help = "search for file paths")]
     path: bool,
+
+    // phone
+    #[arg(long = "phone", help = "search for phone numbers")]
+    phone: bool,
+
+    // semver
+    #[arg(long = "semver", help = "search for semantic versions")]
+    semver: bool,
 
     // uri
     #[arg(long = "uri", help = "search for uris")]
@@ -65,6 +108,22 @@ struct Opts {
     http: bool,
     #[arg(long = "https", help = "alias for: --uri=https")]
     https: bool,
+
+    // uuid
+    #[arg(long = "uuid", help = "search for UUIDs")]
+    uuid: bool,
+}
+
+impl TryFrom<&Opts> for Color {
+    type Error = ();
+
+    fn try_from(opts: &Opts) -> Result<Self, Self::Error> {
+        if !opts.color {
+            return Err(());
+        }
+
+        Ok(Color::default())
+    }
 }
 
 impl TryFrom<&Opts> for Email {
@@ -76,6 +135,75 @@ impl TryFrom<&Opts> for Email {
         }
 
         Ok(Email::default())
+    }
+}
+
+impl TryFrom<&Opts> for Env {
+    type Error = ();
+
+    fn try_from(opts: &Opts) -> Result<Self, Self::Error> {
+        if !opts.env {
+            return Err(());
+        }
+
+        Ok(Env::default())
+    }
+}
+
+impl TryFrom<&Opts> for Hash {
+    type Error = ();
+
+    fn try_from(opts: &Opts) -> Result<Self, Self::Error> {
+        if !(opts.hash_algo.is_some() || opts.md5 || opts.sha1 || opts.sha256 || opts.sha512) {
+            return Err(());
+        }
+
+        let mut finder = Hash::default();
+        if let Some(Some(ref algo)) = opts.hash_algo {
+            for a in algo.split(',') {
+                finder.add_algorithm(a);
+            }
+        }
+        if opts.md5 {
+            finder.add_algorithm("md5");
+        }
+        if opts.sha1 {
+            finder.add_algorithm("sha1");
+        }
+        if opts.sha256 {
+            finder.add_algorithm("sha256");
+        }
+        if opts.sha512 {
+            finder.add_algorithm("sha512");
+        }
+        Ok(finder)
+    }
+}
+
+impl TryFrom<&Opts> for Ip {
+    type Error = ();
+
+    fn try_from(opts: &Opts) -> Result<Self, Self::Error> {
+        if !(opts.ip || opts.ipv4 || opts.ipv6) {
+            return Err(());
+        }
+
+        Ok(Ip {
+            ipv4: opts.ip || opts.ipv4,
+            ipv6: opts.ip || opts.ipv6,
+        })
+    }
+}
+
+impl TryFrom<&Opts> for Json {
+    type Error = ();
+
+    fn try_from(opts: &Opts) -> Result<Self, Self::Error> {
+        if !opts.json {
+            return Err(());
+        }
+
+        Ok(Json::default())
     }
 }
 
@@ -131,6 +259,30 @@ impl TryFrom<&Opts> for Path {
     }
 }
 
+impl TryFrom<&Opts> for Phone {
+    type Error = ();
+
+    fn try_from(opts: &Opts) -> Result<Self, Self::Error> {
+        if !opts.phone {
+            return Err(());
+        }
+
+        Ok(Phone::default())
+    }
+}
+
+impl TryFrom<&Opts> for Semver {
+    type Error = ();
+
+    fn try_from(opts: &Opts) -> Result<Self, Self::Error> {
+        if !opts.semver {
+            return Err(());
+        }
+
+        Ok(Semver::default())
+    }
+}
+
 impl TryFrom<&Opts> for URI {
     type Error = ();
 
@@ -167,22 +319,50 @@ impl TryFrom<&Opts> for URI {
     }
 }
 
+impl TryFrom<&Opts> for Uuid {
+    type Error = ();
+
+    fn try_from(opts: &Opts) -> Result<Self, Self::Error> {
+        if !opts.uuid {
+            return Err(());
+        }
+
+        Ok(Uuid::default())
+    }
+}
+
 fn main() -> ExitCode {
     env_logger::init();
 
     let opts = Opts::parse();
     let codetag = TryInto::<Codetag>::try_into(&opts);
+    let color = TryInto::<Color>::try_into(&opts);
     let email = TryInto::<Email>::try_into(&opts);
+    let env = TryInto::<Env>::try_into(&opts);
+    let hash = TryInto::<Hash>::try_into(&opts);
+    let ip = TryInto::<Ip>::try_into(&opts);
+    let json = TryInto::<Json>::try_into(&opts);
     let mirror = TryInto::<Mirror>::try_into(&opts);
     let path = TryInto::<Path>::try_into(&opts);
+    let phone = TryInto::<Phone>::try_into(&opts);
+    let semver = TryInto::<Semver>::try_into(&opts);
     let uri = TryInto::<URI>::try_into(&opts);
+    let uuid = TryInto::<Uuid>::try_into(&opts);
 
     let finders: Vec<_> = [
         codetag.as_ref().map(|f| f as &dyn Finder),
+        color.as_ref().map(|f| f as &dyn Finder),
         email.as_ref().map(|f| f as &dyn Finder),
+        env.as_ref().map(|f| f as &dyn Finder),
+        hash.as_ref().map(|f| f as &dyn Finder),
+        ip.as_ref().map(|f| f as &dyn Finder),
+        json.as_ref().map(|f| f as &dyn Finder),
         mirror.as_ref().map(|f| f as &dyn Finder),
         path.as_ref().map(|f| f as &dyn Finder),
+        phone.as_ref().map(|f| f as &dyn Finder),
+        semver.as_ref().map(|f| f as &dyn Finder),
         uri.as_ref().map(|f| f as &dyn Finder),
+        uuid.as_ref().map(|f| f as &dyn Finder),
     ]
     .into_iter()
     .filter_map(|finder| finder.ok())

--- a/squeeze-cli/tests/cli.rs
+++ b/squeeze-cli/tests/cli.rs
@@ -290,6 +290,404 @@ fn path_flag_should_extract_multiple_paths() {
 }
 
 // ============================================================================
+// Color extraction tests
+// ============================================================================
+
+#[test]
+fn color_flag_should_extract_hex_color() {
+    squeeze()
+        .arg("--color")
+        .write_stdin("color: #ff00aa\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("#ff00aa"));
+}
+
+#[test]
+fn color_flag_should_extract_short_hex() {
+    squeeze()
+        .arg("--color")
+        .write_stdin("color: #f0a\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("#f0a"));
+}
+
+#[test]
+fn color_flag_should_extract_rgb() {
+    squeeze()
+        .arg("--color")
+        .write_stdin("color: rgb(255, 0, 170)\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("rgb(255, 0, 170)"));
+}
+
+#[test]
+fn color_flag_should_extract_hsl() {
+    squeeze()
+        .arg("--color")
+        .write_stdin("color: hsl(120, 100%, 50%)\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("hsl(120, 100%, 50%)"));
+}
+
+#[test]
+fn color_flag_should_extract_multiple_colors() {
+    squeeze()
+        .arg("--color")
+        .write_stdin("#ff0000 and rgb(0, 255, 0)\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("#ff0000"))
+        .stdout(predicate::str::contains("rgb(0, 255, 0)"));
+}
+
+// ============================================================================
+// Env extraction tests
+// ============================================================================
+
+#[test]
+fn env_flag_should_extract_simple_var() {
+    squeeze()
+        .arg("--env")
+        .write_stdin("use $HOME for path\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("$HOME"));
+}
+
+#[test]
+fn env_flag_should_extract_braced_var() {
+    squeeze()
+        .arg("--env")
+        .write_stdin("use ${PATH} here\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("${PATH}"));
+}
+
+#[test]
+fn env_flag_should_extract_multiple_vars() {
+    squeeze()
+        .arg("--env")
+        .write_stdin("$HOME and ${PATH}\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("$HOME"))
+        .stdout(predicate::str::contains("${PATH}"));
+}
+
+#[test]
+fn env_flag_should_not_match_bare_dollar() {
+    squeeze()
+        .arg("--env")
+        .write_stdin("costs $5\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+}
+
+// ============================================================================
+// Hash extraction tests
+// ============================================================================
+
+#[test]
+fn hash_flag_should_extract_md5() {
+    squeeze()
+        .arg("--hash")
+        .write_stdin("md5: 5d41402abc4b2a76b9719d911017c592\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("5d41402abc4b2a76b9719d911017c592"));
+}
+
+#[test]
+fn hash_flag_should_extract_sha1() {
+    squeeze()
+        .arg("--hash")
+        .write_stdin("sha1: 2aae6c35c94fcfb415dbe95f408b9ce91ee846ed\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed",
+        ));
+}
+
+#[test]
+fn hash_flag_with_algo_filter_should_only_match_specified() {
+    squeeze()
+        .arg("--hash=md5")
+        .write_stdin(
+            "5d41402abc4b2a76b9719d911017c592 and 2aae6c35c94fcfb415dbe95f408b9ce91ee846ed\n",
+        )
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("5d41402abc4b2a76b9719d911017c592"))
+        .stdout(predicate::str::contains("2aae6c35c94fcfb415dbe95f408b9ce91ee846ed").not());
+}
+
+#[test]
+fn md5_alias_should_only_extract_md5() {
+    squeeze()
+        .arg("--md5")
+        .write_stdin(
+            "5d41402abc4b2a76b9719d911017c592 and 2aae6c35c94fcfb415dbe95f408b9ce91ee846ed\n",
+        )
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("5d41402abc4b2a76b9719d911017c592"))
+        .stdout(predicate::str::contains("2aae6c35c94fcfb415dbe95f408b9ce91ee846ed").not());
+}
+
+#[test]
+fn sha1_alias_should_only_extract_sha1() {
+    squeeze()
+        .arg("--sha1")
+        .write_stdin(
+            "5d41402abc4b2a76b9719d911017c592 and 2aae6c35c94fcfb415dbe95f408b9ce91ee846ed\n",
+        )
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed",
+        ))
+        .stdout(predicate::str::contains("5d41402abc4b2a76b9719d911017c592").not());
+}
+
+// ============================================================================
+// IP extraction tests
+// ============================================================================
+
+#[test]
+fn ip_flag_should_extract_ipv4() {
+    squeeze()
+        .arg("--ip")
+        .write_stdin("server at 192.168.1.1\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("192.168.1.1"));
+}
+
+#[test]
+fn ip_flag_should_extract_ipv6_bracketed() {
+    squeeze()
+        .arg("--ip")
+        .write_stdin("connect to [::1]\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("[::1]"));
+}
+
+#[test]
+fn ipv4_flag_should_only_extract_ipv4() {
+    squeeze()
+        .arg("--ipv4")
+        .write_stdin("192.168.1.1 and [::1]\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("192.168.1.1"))
+        .stdout(predicate::str::contains("[::1]").not());
+}
+
+#[test]
+fn ipv6_flag_should_only_extract_ipv6() {
+    squeeze()
+        .arg("--ipv6")
+        .write_stdin("192.168.1.1 and [::1]\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("[::1]"))
+        .stdout(predicate::str::contains("192.168.1.1").not());
+}
+
+// ============================================================================
+// JSON extraction tests
+// ============================================================================
+
+#[test]
+fn json_flag_should_extract_object() {
+    squeeze()
+        .arg("--json")
+        .write_stdin("data: {\"key\": \"value\"}\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("{\"key\": \"value\"}"));
+}
+
+#[test]
+fn json_flag_should_extract_array() {
+    squeeze()
+        .arg("--json")
+        .write_stdin("data: [1, 2, 3]\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("[1, 2, 3]"));
+}
+
+#[test]
+fn json_flag_should_extract_nested() {
+    squeeze()
+        .arg("--json")
+        .write_stdin("{\"a\": {\"b\": [1, 2]}}\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("{\"a\": {\"b\": [1, 2]}}"));
+}
+
+#[test]
+fn json_flag_should_not_match_unclosed() {
+    squeeze()
+        .arg("--json")
+        .write_stdin("{\"key\": \"value\"\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+}
+
+// ============================================================================
+// Phone extraction tests
+// ============================================================================
+
+#[test]
+fn phone_flag_should_extract_e164() {
+    squeeze()
+        .arg("--phone")
+        .write_stdin("call +14155551234\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("+14155551234"));
+}
+
+#[test]
+fn phone_flag_should_extract_parens_format() {
+    squeeze()
+        .arg("--phone")
+        .write_stdin("call (415) 555-1234\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("(415) 555-1234"));
+}
+
+#[test]
+fn phone_flag_should_extract_dashed_format() {
+    squeeze()
+        .arg("--phone")
+        .write_stdin("call 415-555-1234\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("415-555-1234"));
+}
+
+#[test]
+fn phone_flag_should_not_match_plain_digits() {
+    squeeze()
+        .arg("--phone")
+        .write_stdin("number 1234567890\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+}
+
+// ============================================================================
+// Semver extraction tests
+// ============================================================================
+
+#[test]
+fn semver_flag_should_extract_version() {
+    squeeze()
+        .arg("--semver")
+        .write_stdin("version 1.0.0 released\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("1.0.0"));
+}
+
+#[test]
+fn semver_flag_should_extract_version_with_v() {
+    squeeze()
+        .arg("--semver")
+        .write_stdin("tag v2.3.1\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("v2.3.1"));
+}
+
+#[test]
+fn semver_flag_should_extract_prerelease() {
+    squeeze()
+        .arg("--semver")
+        .write_stdin("v1.0.0-rc.1\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("v1.0.0-rc.1"));
+}
+
+#[test]
+fn semver_flag_should_extract_with_build_meta() {
+    squeeze()
+        .arg("--semver")
+        .write_stdin("1.0.0+build.42\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("1.0.0+build.42"));
+}
+
+#[test]
+fn semver_flag_should_not_match_two_components() {
+    squeeze()
+        .arg("--semver")
+        .write_stdin("version 1.0\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+}
+
+// ============================================================================
+// UUID extraction tests
+// ============================================================================
+
+#[test]
+fn uuid_flag_should_extract_uuid() {
+    squeeze()
+        .arg("--uuid")
+        .write_stdin("id: 550e8400-e29b-41d4-a716-446655440000\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "550e8400-e29b-41d4-a716-446655440000",
+        ));
+}
+
+#[test]
+fn uuid_flag_should_extract_multiple_uuids() {
+    squeeze()
+        .arg("--uuid")
+        .write_stdin(
+            "550e8400-e29b-41d4-a716-446655440000 and 6ba7b810-9dad-11d1-80b4-00c04fd430c8\n",
+        )
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "550e8400-e29b-41d4-a716-446655440000",
+        ))
+        .stdout(predicate::str::contains(
+            "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+        ));
+}
+
+#[test]
+fn uuid_flag_should_not_match_no_dashes() {
+    squeeze()
+        .arg("--uuid")
+        .write_stdin("550e8400e29b41d4a716446655440000\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+}
+
+// ============================================================================
 // First flag tests
 // ============================================================================
 

--- a/squeeze-cli/tests/cli.rs
+++ b/squeeze-cli/tests/cli.rs
@@ -170,6 +170,126 @@ fn hide_mnemonic_should_exclude_mnemonic_from_output() {
 }
 
 // ============================================================================
+// Email extraction tests
+// ============================================================================
+
+#[test]
+fn email_flag_should_extract_emails() {
+    squeeze()
+        .arg("--email")
+        .write_stdin("contact user@example.com for info\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("user@example.com"));
+}
+
+#[test]
+fn email_flag_should_extract_multiple_emails() {
+    squeeze()
+        .arg("--email")
+        .write_stdin("cc: alice@one.com and bob@two.org\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("alice@one.com"))
+        .stdout(predicate::str::contains("bob@two.org"));
+}
+
+#[test]
+fn email_flag_should_handle_plus_addressing() {
+    squeeze()
+        .arg("--email")
+        .write_stdin("send to user+tag@example.com\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("user+tag@example.com"));
+}
+
+#[test]
+fn email_flag_should_extract_from_angle_brackets() {
+    squeeze()
+        .arg("--email")
+        .write_stdin("From: Author <author@example.com>\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("author@example.com"));
+}
+
+#[test]
+fn email_flag_should_not_match_bare_at() {
+    squeeze()
+        .arg("--email")
+        .write_stdin("user @ example\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+}
+
+// ============================================================================
+// Path extraction tests
+// ============================================================================
+
+#[test]
+fn path_flag_should_extract_absolute_path() {
+    squeeze()
+        .arg("--path")
+        .write_stdin("see /etc/hosts for details\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("/etc/hosts"));
+}
+
+#[test]
+fn path_flag_should_extract_relative_path() {
+    squeeze()
+        .arg("--path")
+        .write_stdin("edit ./src/main.rs to fix it\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("./src/main.rs"));
+}
+
+#[test]
+fn path_flag_should_extract_home_path() {
+    squeeze()
+        .arg("--path")
+        .write_stdin("config at ~/.config/app.toml\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("~/.config/app.toml"));
+}
+
+#[test]
+fn path_flag_should_extract_path_with_line_number() {
+    squeeze()
+        .arg("--path")
+        .write_stdin("error in ./src/main.rs:42:10 here\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("./src/main.rs:42:10"));
+}
+
+#[test]
+fn path_flag_should_not_match_uris() {
+    squeeze()
+        .arg("--path")
+        .write_stdin("visit https://example.com/path\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+}
+
+#[test]
+fn path_flag_should_extract_multiple_paths() {
+    squeeze()
+        .arg("--path")
+        .write_stdin("copy /etc/hosts to /tmp/hosts\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("/etc/hosts"))
+        .stdout(predicate::str::contains("/tmp/hosts"));
+}
+
+// ============================================================================
 // First flag tests
 // ============================================================================
 

--- a/squeeze-cli/tests/cli.rs
+++ b/squeeze-cli/tests/cli.rs
@@ -688,6 +688,163 @@ fn uuid_flag_should_not_match_no_dashes() {
 }
 
 // ============================================================================
+// CIDR extraction tests
+// ============================================================================
+
+#[test]
+fn cidr_flag_should_extract_ipv4_cidr() {
+    squeeze()
+        .arg("--cidr")
+        .write_stdin("network 192.168.1.0/24 configured\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("192.168.1.0/24"));
+}
+
+#[test]
+fn cidr_flag_should_extract_multiple_cidrs() {
+    squeeze()
+        .arg("--cidr")
+        .write_stdin("10.0.0.0/8 and 172.16.0.0/12\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("10.0.0.0/8"))
+        .stdout(predicate::str::contains("172.16.0.0/12"));
+}
+
+#[test]
+fn cidr_flag_should_extract_ipv6_cidr() {
+    squeeze()
+        .arg("--cidr")
+        .write_stdin("subnet 2001:db8::/32 here\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("2001:db8::/32"));
+}
+
+#[test]
+fn cidr_flag_should_not_match_plain_ip() {
+    squeeze()
+        .arg("--cidr")
+        .write_stdin("host 192.168.1.1 only\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+}
+
+// ============================================================================
+// Datetime extraction tests
+// ============================================================================
+
+#[test]
+fn datetime_flag_should_extract_date() {
+    squeeze()
+        .arg("--datetime")
+        .write_stdin("created on 2024-01-15 by admin\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("2024-01-15"));
+}
+
+#[test]
+fn datetime_flag_should_extract_iso8601() {
+    squeeze()
+        .arg("--datetime")
+        .write_stdin("timestamp: 2024-01-15T10:30:00Z\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("2024-01-15T10:30:00Z"));
+}
+
+#[test]
+fn datetime_flag_should_extract_with_offset() {
+    squeeze()
+        .arg("--datetime")
+        .write_stdin("2024-01-15T10:30:00+05:30\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("2024-01-15T10:30:00+05:30"));
+}
+
+#[test]
+fn datetime_flag_should_not_match_invalid_date() {
+    squeeze()
+        .arg("--datetime")
+        .write_stdin("2024-13-01\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+}
+
+// ============================================================================
+// JWT extraction tests
+// ============================================================================
+
+#[test]
+fn jwt_flag_should_extract_jwt() {
+    squeeze()
+        .arg("--jwt")
+        .write_stdin("token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"));
+}
+
+#[test]
+fn jwt_flag_should_not_match_non_jwt() {
+    squeeze()
+        .arg("--jwt")
+        .write_stdin("abc.def.ghi\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+}
+
+// ============================================================================
+// MAC address extraction tests
+// ============================================================================
+
+#[test]
+fn mac_flag_should_extract_colon_format() {
+    squeeze()
+        .arg("--mac")
+        .write_stdin("device 00:1A:2B:3C:4D:5E connected\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("00:1A:2B:3C:4D:5E"));
+}
+
+#[test]
+fn mac_flag_should_extract_dash_format() {
+    squeeze()
+        .arg("--mac")
+        .write_stdin("device 00-1A-2B-3C-4D-5E connected\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("00-1A-2B-3C-4D-5E"));
+}
+
+#[test]
+fn mac_flag_should_extract_dot_format() {
+    squeeze()
+        .arg("--mac")
+        .write_stdin("device 001A.2B3C.4D5E connected\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("001A.2B3C.4D5E"));
+}
+
+#[test]
+fn mac_flag_should_not_match_short_hex() {
+    squeeze()
+        .arg("--mac")
+        .write_stdin("00:1A:2B:3C:4D\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+}
+
+// ============================================================================
 // First flag tests
 // ============================================================================
 

--- a/squeeze/cidr.rs
+++ b/squeeze/cidr.rs
@@ -1,0 +1,407 @@
+use super::Finder;
+use std::ops::Range;
+
+#[derive(Default)]
+pub struct Cidr {}
+
+impl Cidr {
+    fn try_ipv4_cidr(input: &[u8], idx: usize) -> Option<Range<usize>> {
+        if !input[idx].is_ascii_digit() {
+            return None;
+        }
+
+        // Boundary before: not preceded by digit or dot
+        if idx > 0 && (input[idx - 1].is_ascii_digit() || input[idx - 1] == b'.') {
+            return None;
+        }
+
+        let start = idx;
+        let mut pos = idx;
+
+        // Parse 4 octets
+        for octet_idx in 0..4 {
+            if octet_idx > 0 {
+                if pos >= input.len() || input[pos] != b'.' {
+                    return None;
+                }
+                pos += 1;
+            }
+
+            let octet_start = pos;
+            while pos < input.len() && input[pos].is_ascii_digit() {
+                pos += 1;
+            }
+            let octet_len = pos - octet_start;
+            if octet_len == 0 || octet_len > 3 {
+                return None;
+            }
+
+            if octet_len > 1 && input[octet_start] == b'0' {
+                return None;
+            }
+
+            let octet_str = std::str::from_utf8(&input[octet_start..pos]).ok()?;
+            let value: u16 = octet_str.parse().ok()?;
+            if value > 255 {
+                return None;
+            }
+        }
+
+        // Must have /prefix
+        if pos >= input.len() || input[pos] != b'/' {
+            return None;
+        }
+        pos += 1;
+
+        let prefix_start = pos;
+        while pos < input.len() && input[pos].is_ascii_digit() {
+            pos += 1;
+        }
+        let prefix_len = pos - prefix_start;
+        if prefix_len == 0 || prefix_len > 2 {
+            return None;
+        }
+
+        // No leading zeros in prefix
+        if prefix_len > 1 && input[prefix_start] == b'0' {
+            return None;
+        }
+
+        let prefix_str = std::str::from_utf8(&input[prefix_start..pos]).ok()?;
+        let prefix: u8 = prefix_str.parse().ok()?;
+        if prefix > 32 {
+            return None;
+        }
+
+        // Boundary after: not followed by digit or dot
+        if pos < input.len() && (input[pos].is_ascii_digit() || input[pos] == b'.') {
+            return None;
+        }
+
+        Some(start..pos)
+    }
+
+    fn try_ipv6_cidr(input: &[u8], idx: usize) -> Option<Range<usize>> {
+        // Look for IPv6 addresses followed by /prefix
+        // Handle both bare and bracketed forms
+        let (ip_start, ip_end) = if input[idx] == b'[' {
+            let close = input[idx..].iter().position(|&b| b == b']')?;
+            let close_pos = idx + close;
+            let inner = &input[idx + 1..close_pos];
+            if !Self::is_valid_ipv6(inner) {
+                return None;
+            }
+            (idx, close_pos + 1)
+        } else {
+            if !input[idx].is_ascii_hexdigit() && input[idx] != b':' {
+                return None;
+            }
+            // Boundary before
+            if idx > 0 && (input[idx - 1].is_ascii_alphanumeric() || input[idx - 1] == b':') {
+                return None;
+            }
+
+            let start = idx;
+            let mut end = idx;
+            while end < input.len()
+                && (input[end].is_ascii_hexdigit() || input[end] == b':')
+            {
+                end += 1;
+            }
+
+            // Strip trailing colons (except ::)
+            while end > start && input[end - 1] == b':' && !(end >= 2 && input[end - 2] == b':')
+            {
+                end -= 1;
+            }
+
+            let candidate = &input[start..end];
+            if !candidate.contains(&b':') {
+                return None;
+            }
+            if !Self::is_valid_ipv6(candidate) {
+                return None;
+            }
+            (start, end)
+        };
+
+        // Must have /prefix
+        if ip_end >= input.len() || input[ip_end] != b'/' {
+            return None;
+        }
+        let mut pos = ip_end + 1;
+
+        let prefix_start = pos;
+        while pos < input.len() && input[pos].is_ascii_digit() {
+            pos += 1;
+        }
+        let prefix_len = pos - prefix_start;
+        if prefix_len == 0 || prefix_len > 3 {
+            return None;
+        }
+
+        if prefix_len > 1 && input[prefix_start] == b'0' {
+            return None;
+        }
+
+        let prefix_str = std::str::from_utf8(&input[prefix_start..pos]).ok()?;
+        let prefix: u16 = prefix_str.parse().ok()?;
+        if prefix > 128 {
+            return None;
+        }
+
+        // Boundary after
+        if pos < input.len() && (input[pos].is_ascii_digit() || input[pos] == b'.') {
+            return None;
+        }
+
+        Some(ip_start..pos)
+    }
+
+    fn is_valid_ipv6(bytes: &[u8]) -> bool {
+        let s = match std::str::from_utf8(bytes) {
+            Ok(s) => s,
+            Err(_) => return false,
+        };
+
+        if s == "::" {
+            return true;
+        }
+
+        let has_double_colon = s.contains("::");
+
+        if has_double_colon {
+            let parts: Vec<&str> = s.splitn(2, "::").collect();
+            if parts.len() != 2 {
+                return false;
+            }
+
+            let left: Vec<&str> = if parts[0].is_empty() {
+                vec![]
+            } else {
+                parts[0].split(':').collect()
+            };
+
+            let right: Vec<&str> = if parts[1].is_empty() {
+                vec![]
+            } else {
+                parts[1].split(':').collect()
+            };
+
+            let total = left.len() + right.len();
+            if total >= 8 {
+                return false;
+            }
+
+            left.iter()
+                .chain(right.iter())
+                .all(|g| Self::is_valid_hex_group(g))
+        } else {
+            let groups: Vec<&str> = s.split(':').collect();
+            groups.len() == 8 && groups.iter().all(|g| Self::is_valid_hex_group(g))
+        }
+    }
+
+    fn is_valid_hex_group(g: &str) -> bool {
+        !g.is_empty() && g.len() <= 4 && g.bytes().all(|b| b.is_ascii_hexdigit())
+    }
+}
+
+impl Finder for Cidr {
+    fn id(&self) -> &'static str {
+        "cidr"
+    }
+
+    fn find(&self, s: &str) -> Option<Range<usize>> {
+        let input = s.as_bytes();
+        let mut idx = 0;
+
+        while idx < input.len() {
+            if input[idx].is_ascii_digit() {
+                if let Some(range) = Self::try_ipv4_cidr(input, idx) {
+                    return Some(range);
+                }
+            }
+
+            if input[idx] == b'[' || input[idx].is_ascii_hexdigit() || input[idx] == b':' {
+                if let Some(range) = Self::try_ipv6_cidr(input, idx) {
+                    return Some(range);
+                }
+            }
+
+            idx += 1;
+        }
+
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn id_should_return_cidr() {
+        let finder = Cidr::default();
+        assert_eq!("cidr", finder.id());
+    }
+
+    // IPv4 CIDR
+    #[test]
+    fn find_should_extract_ipv4_cidr() {
+        let finder = Cidr::default();
+        let input = "network 192.168.1.0/24 is local";
+        let range = finder.find(input).unwrap();
+        assert_eq!("192.168.1.0/24", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_class_a() {
+        let finder = Cidr::default();
+        let input = "10.0.0.0/8";
+        let range = finder.find(input).unwrap();
+        assert_eq!("10.0.0.0/8", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_host_route() {
+        let finder = Cidr::default();
+        let input = "host 10.0.0.1/32 route";
+        let range = finder.find(input).unwrap();
+        assert_eq!("10.0.0.1/32", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_default_route() {
+        let finder = Cidr::default();
+        let input = "0.0.0.0/0";
+        let range = finder.find(input).unwrap();
+        assert_eq!("0.0.0.0/0", &input[range]);
+    }
+
+    #[test]
+    fn find_should_reject_prefix_over_32() {
+        let finder = Cidr::default();
+        assert!(finder.find("192.168.1.0/33").is_none());
+    }
+
+    #[test]
+    fn find_should_reject_no_prefix() {
+        let finder = Cidr::default();
+        assert!(finder.find("only 192.168.1.0 here").is_none());
+    }
+
+    #[test]
+    fn find_should_reject_invalid_octet() {
+        let finder = Cidr::default();
+        assert!(finder.find("256.168.1.0/24").is_none());
+    }
+
+    #[test]
+    fn find_should_reject_leading_zero_octet() {
+        let finder = Cidr::default();
+        assert!(finder.find("192.168.01.0/24").is_none());
+    }
+
+    #[test]
+    fn find_should_reject_leading_zero_prefix() {
+        let finder = Cidr::default();
+        assert!(finder.find("192.168.1.0/08").is_none());
+    }
+
+    #[test]
+    fn find_should_reject_preceded_by_digit() {
+        let finder = Cidr::default();
+        assert!(finder.find("x1192.168.1.0/24").is_none());
+    }
+
+    #[test]
+    fn find_should_reject_followed_by_digit() {
+        let finder = Cidr::default();
+        assert!(finder.find("192.168.1.0/245").is_none());
+    }
+
+    // IPv6 CIDR
+    #[test]
+    fn find_should_extract_ipv6_cidr() {
+        let finder = Cidr::default();
+        let input = "network 2001:db8::/32 configured";
+        let range = finder.find(input).unwrap();
+        assert_eq!("2001:db8::/32", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_ipv6_full_cidr() {
+        let finder = Cidr::default();
+        let input = "2001:0db8:85a3:0000:0000:8a2e:0370:7334/64";
+        let range = finder.find(input).unwrap();
+        assert_eq!(
+            "2001:0db8:85a3:0000:0000:8a2e:0370:7334/64",
+            &input[range]
+        );
+    }
+
+    #[test]
+    fn find_should_extract_ipv6_loopback_cidr() {
+        let finder = Cidr::default();
+        let input = "::1/128";
+        let range = finder.find(input).unwrap();
+        assert_eq!("::1/128", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_ipv6_default_cidr() {
+        let finder = Cidr::default();
+        let input = "::/0";
+        let range = finder.find(input).unwrap();
+        assert_eq!("::/0", &input[range]);
+    }
+
+    #[test]
+    fn find_should_reject_ipv6_prefix_over_128() {
+        let finder = Cidr::default();
+        assert!(finder.find("2001:db8::/129").is_none());
+    }
+
+    // Multiple
+    #[test]
+    fn find_should_extract_multiple_cidrs_iteratively() {
+        let finder = Cidr::default();
+        let input = "10.0.0.0/8 and 192.168.1.0/24";
+
+        let mut results = Vec::new();
+        let mut idx = 0;
+        while idx < input.len() {
+            if let Some(range) = finder.find(&input[idx..]) {
+                results.push(&input[idx + range.start..idx + range.end]);
+                idx += range.end;
+            } else {
+                break;
+            }
+        }
+
+        assert_eq!(vec!["10.0.0.0/8", "192.168.1.0/24"], results);
+    }
+
+    #[test]
+    fn find_should_handle_empty_input() {
+        let finder = Cidr::default();
+        assert!(finder.find("").is_none());
+    }
+
+    #[test]
+    fn find_should_extract_cidr_at_start() {
+        let finder = Cidr::default();
+        let input = "10.0.0.0/8 is class A";
+        let range = finder.find(input).unwrap();
+        assert_eq!("10.0.0.0/8", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_cidr_at_end() {
+        let finder = Cidr::default();
+        let input = "subnet is 172.16.0.0/12";
+        let range = finder.find(input).unwrap();
+        assert_eq!("172.16.0.0/12", &input[range]);
+    }
+}

--- a/squeeze/cidr.rs
+++ b/squeeze/cidr.rs
@@ -103,15 +103,12 @@ impl Cidr {
 
             let start = idx;
             let mut end = idx;
-            while end < input.len()
-                && (input[end].is_ascii_hexdigit() || input[end] == b':')
-            {
+            while end < input.len() && (input[end].is_ascii_hexdigit() || input[end] == b':') {
                 end += 1;
             }
 
             // Strip trailing colons (except ::)
-            while end > start && input[end - 1] == b':' && !(end >= 2 && input[end - 2] == b':')
-            {
+            while end > start && input[end - 1] == b':' && !(end >= 2 && input[end - 2] == b':') {
                 end -= 1;
             }
 
@@ -335,10 +332,7 @@ mod tests {
         let finder = Cidr::default();
         let input = "2001:0db8:85a3:0000:0000:8a2e:0370:7334/64";
         let range = finder.find(input).unwrap();
-        assert_eq!(
-            "2001:0db8:85a3:0000:0000:8a2e:0370:7334/64",
-            &input[range]
-        );
+        assert_eq!("2001:0db8:85a3:0000:0000:8a2e:0370:7334/64", &input[range]);
     }
 
     #[test]

--- a/squeeze/color.rs
+++ b/squeeze/color.rs
@@ -1,0 +1,266 @@
+use super::Finder;
+use std::ops::Range;
+
+#[derive(Default)]
+pub struct Color {}
+
+impl Color {
+    fn is_hex(b: u8) -> bool {
+        b.is_ascii_hexdigit()
+    }
+
+    fn try_hex_color(input: &[u8], pos: usize) -> Option<Range<usize>> {
+        if input[pos] != b'#' {
+            return None;
+        }
+
+        let start = pos;
+        let after_hash = pos + 1;
+        if after_hash >= input.len() || !Self::is_hex(input[after_hash]) {
+            return None;
+        }
+
+        let mut hex_end = after_hash;
+        while hex_end < input.len() && Self::is_hex(input[hex_end]) {
+            hex_end += 1;
+        }
+
+        let hex_len = hex_end - after_hash;
+
+        // Check boundary after: must not be followed by a hex digit
+        let has_boundary = hex_end >= input.len() || !Self::is_hex(input[hex_end]);
+        if !has_boundary {
+            return None;
+        }
+
+        // Match longest valid: 8, 6, 4, 3
+        for &valid_len in &[8, 6, 4, 3] {
+            if hex_len == valid_len {
+                return Some(start..after_hash + valid_len);
+            }
+        }
+
+        None
+    }
+
+    fn try_css_function(input: &[u8], pos: usize) -> Option<Range<usize>> {
+        let remaining = &input[pos..];
+
+        let prefixes: &[&[u8]] = &[b"rgba(", b"rgb(", b"hsla(", b"hsl("];
+
+        let mut matched_len = 0;
+        for prefix in prefixes {
+            if remaining.len() >= prefix.len()
+                && remaining[..prefix.len()].eq_ignore_ascii_case(prefix)
+            {
+                matched_len = prefix.len();
+                break;
+            }
+        }
+
+        if matched_len == 0 {
+            return None;
+        }
+
+        // Check boundary before: not preceded by alphanumeric
+        if pos > 0 && input[pos - 1].is_ascii_alphanumeric() {
+            return None;
+        }
+
+        let mut end = pos + matched_len;
+        let mut depth = 1;
+
+        while end < input.len() && depth > 0 {
+            match input[end] {
+                b'(' => depth += 1,
+                b')' => depth -= 1,
+                _ => {}
+            }
+            end += 1;
+        }
+
+        if depth == 0 {
+            Some(pos..end)
+        } else {
+            None
+        }
+    }
+}
+
+impl Finder for Color {
+    fn id(&self) -> &'static str {
+        "color"
+    }
+
+    fn find(&self, s: &str) -> Option<Range<usize>> {
+        let input = s.as_bytes();
+        let mut idx = 0;
+
+        while idx < input.len() {
+            if input[idx] == b'#' {
+                if let Some(range) = Self::try_hex_color(input, idx) {
+                    return Some(range);
+                }
+            }
+
+            if matches!(input[idx], b'r' | b'R' | b'h' | b'H') {
+                if let Some(range) = Self::try_css_function(input, idx) {
+                    return Some(range);
+                }
+            }
+
+            idx += 1;
+        }
+
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn id_should_return_color() {
+        let finder = Color::default();
+        assert_eq!("color", finder.id());
+    }
+
+    // Hex colors
+    #[test]
+    fn find_should_extract_6_digit_hex() {
+        let finder = Color::default();
+        let input = "color: #ff00aa";
+        let range = finder.find(input).unwrap();
+        assert_eq!("#ff00aa", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_3_digit_hex() {
+        let finder = Color::default();
+        let input = "color: #f0a";
+        let range = finder.find(input).unwrap();
+        assert_eq!("#f0a", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_8_digit_hex() {
+        let finder = Color::default();
+        let input = "#ff00aa80 with alpha";
+        let range = finder.find(input).unwrap();
+        assert_eq!("#ff00aa80", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_4_digit_hex() {
+        let finder = Color::default();
+        let input = "#f0a8 short alpha";
+        let range = finder.find(input).unwrap();
+        assert_eq!("#f0a8", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_uppercase_hex() {
+        let finder = Color::default();
+        let input = "#FF00AA";
+        let range = finder.find(input).unwrap();
+        assert_eq!("#FF00AA", &input[range]);
+    }
+
+    #[test]
+    fn find_should_reject_5_digit_hex() {
+        let finder = Color::default();
+        assert!(finder.find("#ff00a").is_none());
+    }
+
+    #[test]
+    fn find_should_reject_1_digit_hex() {
+        let finder = Color::default();
+        assert!(finder.find("#f ").is_none());
+    }
+
+    #[test]
+    fn find_should_reject_hash_with_non_hex() {
+        let finder = Color::default();
+        assert!(finder.find("#gghhii").is_none());
+    }
+
+    // CSS functions
+    #[test]
+    fn find_should_extract_rgb() {
+        let finder = Color::default();
+        let input = "color: rgb(255, 0, 170)";
+        let range = finder.find(input).unwrap();
+        assert_eq!("rgb(255, 0, 170)", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_rgba() {
+        let finder = Color::default();
+        let input = "rgba(255, 0, 170, 0.5)";
+        let range = finder.find(input).unwrap();
+        assert_eq!("rgba(255, 0, 170, 0.5)", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_hsl() {
+        let finder = Color::default();
+        let input = "hsl(120, 100%, 50%)";
+        let range = finder.find(input).unwrap();
+        assert_eq!("hsl(120, 100%, 50%)", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_hsla() {
+        let finder = Color::default();
+        let input = "hsla(120, 100%, 50%, 0.8)";
+        let range = finder.find(input).unwrap();
+        assert_eq!("hsla(120, 100%, 50%, 0.8)", &input[range]);
+    }
+
+    #[test]
+    fn find_should_not_match_rgb_preceded_by_alpha() {
+        let finder = Color::default();
+        assert!(finder.find("srgb(1, 2, 3)").is_none());
+    }
+
+    #[test]
+    fn find_should_reject_unclosed_rgb() {
+        let finder = Color::default();
+        assert!(finder.find("rgb(255, 0, 170").is_none());
+    }
+
+    // Multiple
+    #[test]
+    fn find_should_extract_multiple_colors_iteratively() {
+        let finder = Color::default();
+        let input = "#ff0000 and rgb(0, 255, 0)";
+
+        let mut results = Vec::new();
+        let mut idx = 0;
+        while idx < input.len() {
+            if let Some(range) = finder.find(&input[idx..]) {
+                results.push(&input[idx + range.start..idx + range.end]);
+                idx += range.end;
+            } else {
+                break;
+            }
+        }
+
+        assert_eq!(vec!["#ff0000", "rgb(0, 255, 0)"], results);
+    }
+
+    #[test]
+    fn find_should_handle_empty_input() {
+        let finder = Color::default();
+        assert!(finder.find("").is_none());
+    }
+
+    #[test]
+    fn find_should_extract_hex_in_css() {
+        let finder = Color::default();
+        let input = "background-color: #333;";
+        let range = finder.find(input).unwrap();
+        assert_eq!("#333", &input[range]);
+    }
+}

--- a/squeeze/datetime.rs
+++ b/squeeze/datetime.rs
@@ -1,0 +1,364 @@
+use super::Finder;
+use std::ops::Range;
+
+#[derive(Default)]
+pub struct Datetime {}
+
+impl Datetime {
+    fn try_date(input: &[u8], idx: usize) -> Option<Range<usize>> {
+        // YYYY-MM-DD with optional time component
+        if idx + 10 > input.len() {
+            return None;
+        }
+
+        // Boundary before: not preceded by digit or dash
+        if idx > 0 && (input[idx - 1].is_ascii_digit() || input[idx - 1] == b'-') {
+            return None;
+        }
+
+        // YYYY
+        if !Self::is_4_digits(input, idx) {
+            return None;
+        }
+        let year = Self::parse_num(input, idx, 4)?;
+        if !(1000..=9999).contains(&year) {
+            return None;
+        }
+
+        if input[idx + 4] != b'-' {
+            return None;
+        }
+
+        // MM
+        if !Self::is_2_digits(input, idx + 5) {
+            return None;
+        }
+        let month = Self::parse_num(input, idx + 5, 2)?;
+        if !(1..=12).contains(&month) {
+            return None;
+        }
+
+        if input[idx + 7] != b'-' {
+            return None;
+        }
+
+        // DD
+        if !Self::is_2_digits(input, idx + 8) {
+            return None;
+        }
+        let day = Self::parse_num(input, idx + 8, 2)?;
+        if !(1..=31).contains(&day) {
+            return None;
+        }
+
+        let mut end = idx + 10;
+
+        // Optional time component: T or space followed by HH:MM
+        if end < input.len() && (input[end] == b'T' || input[end] == b' ') {
+            if let Some(time_end) = Self::try_time(input, end + 1) {
+                // Only accept space separator if it's 'T' or if followed by valid time
+                if input[end] == b'T' || time_end > end + 1 {
+                    end = time_end;
+                }
+            }
+        }
+
+        // Boundary after: not followed by digit or dash
+        if end < input.len() && (input[end].is_ascii_digit() || input[end] == b'-') {
+            return None;
+        }
+
+        Some(idx..end)
+    }
+
+    fn try_time(input: &[u8], idx: usize) -> Option<usize> {
+        // HH:MM[:SS[.fractional]]
+        if idx + 5 > input.len() {
+            return None;
+        }
+
+        if !Self::is_2_digits(input, idx) {
+            return None;
+        }
+        let hour = Self::parse_num(input, idx, 2)?;
+        if hour > 23 {
+            return None;
+        }
+
+        if input[idx + 2] != b':' {
+            return None;
+        }
+
+        if !Self::is_2_digits(input, idx + 3) {
+            return None;
+        }
+        let minute = Self::parse_num(input, idx + 3, 2)?;
+        if minute > 59 {
+            return None;
+        }
+
+        let mut end = idx + 5;
+
+        // Optional :SS
+        if end + 3 <= input.len() && input[end] == b':' && Self::is_2_digits(input, end + 1) {
+            let second = Self::parse_num(input, end + 1, 2)?;
+            if second <= 60 {
+                end += 3;
+
+                // Optional fractional seconds
+                if end < input.len() && input[end] == b'.' {
+                    let frac_start = end + 1;
+                    let mut frac_end = frac_start;
+                    while frac_end < input.len() && input[frac_end].is_ascii_digit() {
+                        frac_end += 1;
+                    }
+                    if frac_end > frac_start {
+                        end = frac_end;
+                    }
+                }
+            }
+        }
+
+        // Optional timezone: Z, +HH:MM, -HH:MM
+        if end < input.len() && input[end] == b'Z' {
+            end += 1;
+        } else if end + 6 <= input.len()
+            && (input[end] == b'+' || input[end] == b'-')
+            && Self::is_2_digits(input, end + 1)
+            && input[end + 3] == b':'
+            && Self::is_2_digits(input, end + 4)
+        {
+            end += 6;
+        }
+
+        Some(end)
+    }
+
+    fn is_2_digits(input: &[u8], pos: usize) -> bool {
+        pos + 2 <= input.len() && input[pos].is_ascii_digit() && input[pos + 1].is_ascii_digit()
+    }
+
+    fn is_4_digits(input: &[u8], pos: usize) -> bool {
+        pos + 4 <= input.len()
+            && input[pos].is_ascii_digit()
+            && input[pos + 1].is_ascii_digit()
+            && input[pos + 2].is_ascii_digit()
+            && input[pos + 3].is_ascii_digit()
+    }
+
+    fn parse_num(input: &[u8], pos: usize, len: usize) -> Option<u32> {
+        std::str::from_utf8(&input[pos..pos + len])
+            .ok()?
+            .parse()
+            .ok()
+    }
+}
+
+impl Finder for Datetime {
+    fn id(&self) -> &'static str {
+        "datetime"
+    }
+
+    fn find(&self, s: &str) -> Option<Range<usize>> {
+        let input = s.as_bytes();
+        let mut idx = 0;
+
+        while idx + 10 <= input.len() {
+            if input[idx].is_ascii_digit() {
+                if let Some(range) = Self::try_date(input, idx) {
+                    return Some(range);
+                }
+            }
+            idx += 1;
+        }
+
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn id_should_return_datetime() {
+        let finder = Datetime::default();
+        assert_eq!("datetime", finder.id());
+    }
+
+    #[test]
+    fn find_should_extract_date() {
+        let finder = Datetime::default();
+        let input = "created on 2024-01-15 by admin";
+        let range = finder.find(input).unwrap();
+        assert_eq!("2024-01-15", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_datetime_with_t() {
+        let finder = Datetime::default();
+        let input = "timestamp: 2024-01-15T10:30:00";
+        let range = finder.find(input).unwrap();
+        assert_eq!("2024-01-15T10:30:00", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_datetime_with_timezone_z() {
+        let finder = Datetime::default();
+        let input = "2024-01-15T10:30:00Z";
+        let range = finder.find(input).unwrap();
+        assert_eq!("2024-01-15T10:30:00Z", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_datetime_with_timezone_offset() {
+        let finder = Datetime::default();
+        let input = "2024-01-15T10:30:00+05:30";
+        let range = finder.find(input).unwrap();
+        assert_eq!("2024-01-15T10:30:00+05:30", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_datetime_with_negative_offset() {
+        let finder = Datetime::default();
+        let input = "2024-01-15T10:30:00-08:00";
+        let range = finder.find(input).unwrap();
+        assert_eq!("2024-01-15T10:30:00-08:00", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_datetime_with_fractional_seconds() {
+        let finder = Datetime::default();
+        let input = "2024-01-15T10:30:00.123Z";
+        let range = finder.find(input).unwrap();
+        assert_eq!("2024-01-15T10:30:00.123Z", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_datetime_with_fractional_and_offset() {
+        let finder = Datetime::default();
+        let input = "2024-01-15T10:30:00.123456+02:00";
+        let range = finder.find(input).unwrap();
+        assert_eq!("2024-01-15T10:30:00.123456+02:00", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_datetime_without_seconds() {
+        let finder = Datetime::default();
+        let input = "2024-01-15T10:30Z";
+        let range = finder.find(input).unwrap();
+        assert_eq!("2024-01-15T10:30Z", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_date_in_text() {
+        let finder = Datetime::default();
+        let input = "deployed on 2024-12-25 successfully";
+        let range = finder.find(input).unwrap();
+        assert_eq!("2024-12-25", &input[range]);
+    }
+
+    #[test]
+    fn find_should_reject_invalid_month() {
+        let finder = Datetime::default();
+        assert!(finder.find("2024-13-01").is_none());
+    }
+
+    #[test]
+    fn find_should_reject_invalid_day() {
+        let finder = Datetime::default();
+        assert!(finder.find("2024-01-32").is_none());
+    }
+
+    #[test]
+    fn find_should_reject_month_zero() {
+        let finder = Datetime::default();
+        assert!(finder.find("2024-00-15").is_none());
+    }
+
+    #[test]
+    fn find_should_reject_day_zero() {
+        let finder = Datetime::default();
+        assert!(finder.find("2024-01-00").is_none());
+    }
+
+    #[test]
+    fn find_should_reject_preceded_by_digit() {
+        let finder = Datetime::default();
+        assert!(finder.find("x12024-01-15").is_none());
+    }
+
+    #[test]
+    fn find_should_reject_followed_by_digit() {
+        let finder = Datetime::default();
+        assert!(finder.find("2024-01-155").is_none());
+    }
+
+    #[test]
+    fn find_should_handle_empty_input() {
+        let finder = Datetime::default();
+        assert!(finder.find("").is_none());
+    }
+
+    #[test]
+    fn find_should_extract_multiple_datetimes_iteratively() {
+        let finder = Datetime::default();
+        let input = "2024-01-15T10:00:00Z to 2024-01-16T12:00:00Z";
+
+        let mut results = Vec::new();
+        let mut idx = 0;
+        while idx < input.len() {
+            if let Some(range) = finder.find(&input[idx..]) {
+                results.push(&input[idx + range.start..idx + range.end]);
+                idx += range.end;
+            } else {
+                break;
+            }
+        }
+
+        assert_eq!(
+            vec!["2024-01-15T10:00:00Z", "2024-01-16T12:00:00Z"],
+            results
+        );
+    }
+
+    #[test]
+    fn find_should_extract_date_at_start() {
+        let finder = Datetime::default();
+        let input = "2024-01-15 is the date";
+        let range = finder.find(input).unwrap();
+        assert_eq!("2024-01-15", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_date_at_end() {
+        let finder = Datetime::default();
+        let input = "the date is 2024-01-15";
+        let range = finder.find(input).unwrap();
+        assert_eq!("2024-01-15", &input[range]);
+    }
+
+    #[test]
+    fn find_should_reject_invalid_hour() {
+        let finder = Datetime::default();
+        let input = "2024-01-15T25:00:00";
+        let range = finder.find(input).unwrap();
+        assert_eq!("2024-01-15", &input[range]);
+    }
+
+    #[test]
+    fn find_should_reject_invalid_minute() {
+        let finder = Datetime::default();
+        let input = "2024-01-15T10:61:00";
+        let range = finder.find(input).unwrap();
+        assert_eq!("2024-01-15", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_datetime_with_space_separator() {
+        let finder = Datetime::default();
+        let input = "log: 2024-01-15 10:30:00";
+        let range = finder.find(input).unwrap();
+        assert_eq!("2024-01-15 10:30:00", &input[range]);
+    }
+}

--- a/squeeze/email.rs
+++ b/squeeze/email.rs
@@ -51,10 +51,7 @@ impl Finder for Email {
             }
 
             // Local part must be non-empty and not start/end with '.'
-            if local_start == at_pos
-                || input[local_start] == b'.'
-                || input[at_pos - 1] == b'.'
-            {
+            if local_start == at_pos || input[local_start] == b'.' || input[at_pos - 1] == b'.' {
                 idx = at_pos + 1;
                 continue;
             }
@@ -76,9 +73,7 @@ impl Finder for Email {
             }
 
             // Strip trailing dots/hyphens
-            while domain_end > domain_start
-                && matches!(input[domain_end - 1], b'.' | b'-')
-            {
+            while domain_end > domain_start && matches!(input[domain_end - 1], b'.' | b'-') {
                 domain_end -= 1;
             }
 
@@ -95,7 +90,9 @@ impl Finder for Email {
                 !label.is_empty()
                     && !label.starts_with('-')
                     && !label.ends_with('-')
-                    && label.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'-')
+                    && label
+                        .bytes()
+                        .all(|b| b.is_ascii_alphanumeric() || b == b'-')
             });
 
             if !valid {

--- a/squeeze/email.rs
+++ b/squeeze/email.rs
@@ -1,0 +1,294 @@
+use super::Finder;
+use std::ops::Range;
+
+#[derive(Default)]
+pub struct Email {}
+
+impl Email {
+    fn is_local_char(b: u8) -> bool {
+        b.is_ascii_alphanumeric()
+            || matches!(
+                b,
+                b'.' | b'!'
+                    | b'#'
+                    | b'$'
+                    | b'%'
+                    | b'&'
+                    | b'\''
+                    | b'*'
+                    | b'+'
+                    | b'/'
+                    | b'='
+                    | b'?'
+                    | b'^'
+                    | b'_'
+                    | b'`'
+                    | b'{'
+                    | b'|'
+                    | b'}'
+                    | b'~'
+                    | b'-'
+            )
+    }
+}
+
+impl Finder for Email {
+    fn id(&self) -> &'static str {
+        "email"
+    }
+
+    fn find(&self, s: &str) -> Option<Range<usize>> {
+        let input = s.as_bytes();
+        let mut idx = 0;
+
+        while idx < input.len() {
+            let at_pos = idx + input[idx..].iter().position(|&b| b == b'@')?;
+
+            // Walk backwards for local part
+            let mut local_start = at_pos;
+            while local_start > idx && Self::is_local_char(input[local_start - 1]) {
+                local_start -= 1;
+            }
+
+            // Local part must be non-empty and not start/end with '.'
+            if local_start == at_pos
+                || input[local_start] == b'.'
+                || input[at_pos - 1] == b'.'
+            {
+                idx = at_pos + 1;
+                continue;
+            }
+
+            // Walk forwards for domain
+            let domain_start = at_pos + 1;
+            let mut domain_end = domain_start;
+            while domain_end < input.len()
+                && (input[domain_end].is_ascii_alphanumeric()
+                    || input[domain_end] == b'-'
+                    || input[domain_end] == b'.')
+            {
+                domain_end += 1;
+            }
+
+            if domain_end == domain_start {
+                idx = at_pos + 1;
+                continue;
+            }
+
+            // Strip trailing dots/hyphens
+            while domain_end > domain_start
+                && matches!(input[domain_end - 1], b'.' | b'-')
+            {
+                domain_end -= 1;
+            }
+
+            let domain = &s[domain_start..domain_end];
+
+            // Must have at least one dot
+            if !domain.contains('.') {
+                idx = at_pos + 1;
+                continue;
+            }
+
+            // Validate each label
+            let valid = domain.split('.').all(|label| {
+                !label.is_empty()
+                    && !label.starts_with('-')
+                    && !label.ends_with('-')
+                    && label.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'-')
+            });
+
+            if !valid {
+                idx = at_pos + 1;
+                continue;
+            }
+
+            // TLD must be >= 2 chars and all alpha
+            let tld = domain.rsplit('.').next().unwrap();
+            if tld.len() < 2 || !tld.bytes().all(|b| b.is_ascii_alphabetic()) {
+                idx = at_pos + 1;
+                continue;
+            }
+
+            return Some(local_start..domain_end);
+        }
+
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn id_should_return_email() {
+        let finder = Email::default();
+        assert_eq!("email", finder.id());
+    }
+
+    #[test]
+    fn find_should_extract_simple_email() {
+        let finder = Email::default();
+        let input = "contact user@example.com for info";
+        let range = finder.find(input).unwrap();
+        assert_eq!("user@example.com", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_email_at_start() {
+        let finder = Email::default();
+        let input = "alice@example.org is here";
+        let range = finder.find(input).unwrap();
+        assert_eq!("alice@example.org", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_email_at_end() {
+        let finder = Email::default();
+        let input = "send to bob@test.co";
+        let range = finder.find(input).unwrap();
+        assert_eq!("bob@test.co", &input[range]);
+    }
+
+    #[test]
+    fn find_should_handle_plus_addressing() {
+        let finder = Email::default();
+        let input = "user+tag@example.com";
+        let range = finder.find(input).unwrap();
+        assert_eq!("user+tag@example.com", &input[range]);
+    }
+
+    #[test]
+    fn find_should_handle_dots_in_local_part() {
+        let finder = Email::default();
+        let input = "first.last@example.com";
+        let range = finder.find(input).unwrap();
+        assert_eq!("first.last@example.com", &input[range]);
+    }
+
+    #[test]
+    fn find_should_handle_subdomain() {
+        let finder = Email::default();
+        let input = "user@mail.example.co.uk";
+        let range = finder.find(input).unwrap();
+        assert_eq!("user@mail.example.co.uk", &input[range]);
+    }
+
+    #[test]
+    fn find_should_handle_hyphenated_domain() {
+        let finder = Email::default();
+        let input = "user@my-company.example.com";
+        let range = finder.find(input).unwrap();
+        assert_eq!("user@my-company.example.com", &input[range]);
+    }
+
+    #[test]
+    fn find_should_reject_no_at_sign() {
+        let finder = Email::default();
+        assert!(finder.find("not an email").is_none());
+    }
+
+    #[test]
+    fn find_should_reject_no_domain_dot() {
+        let finder = Email::default();
+        assert!(finder.find("user@localhost").is_none());
+    }
+
+    #[test]
+    fn find_should_reject_empty_local_part() {
+        let finder = Email::default();
+        assert!(finder.find("@example.com").is_none());
+    }
+
+    #[test]
+    fn find_should_reject_dot_start_local() {
+        let finder = Email::default();
+        assert!(finder.find(".user@example.com").is_none());
+    }
+
+    #[test]
+    fn find_should_reject_dot_end_local() {
+        let finder = Email::default();
+        assert!(finder.find("user.@example.com").is_none());
+    }
+
+    #[test]
+    fn find_should_reject_single_char_tld() {
+        let finder = Email::default();
+        assert!(finder.find("user@example.x").is_none());
+    }
+
+    #[test]
+    fn find_should_reject_numeric_tld() {
+        let finder = Email::default();
+        assert!(finder.find("user@example.123").is_none());
+    }
+
+    #[test]
+    fn find_should_reject_domain_starting_with_hyphen() {
+        let finder = Email::default();
+        assert!(finder.find("user@-example.com").is_none());
+    }
+
+    #[test]
+    fn find_should_reject_domain_ending_with_hyphen() {
+        let finder = Email::default();
+        assert!(finder.find("user@example-.com").is_none());
+    }
+
+    #[test]
+    fn find_should_extract_email_from_angle_brackets() {
+        let finder = Email::default();
+        let input = "Author <author@example.com>";
+        let range = finder.find(input).unwrap();
+        assert_eq!("author@example.com", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_multiple_emails_iteratively() {
+        let finder = Email::default();
+        let input = "cc: alice@one.com and bob@two.org";
+
+        let mut results = Vec::new();
+        let mut idx = 0;
+        while idx < input.len() {
+            if let Some(range) = finder.find(&input[idx..]) {
+                results.push(&input[idx + range.start..idx + range.end]);
+                idx += range.end;
+            } else {
+                break;
+            }
+        }
+
+        assert_eq!(vec!["alice@one.com", "bob@two.org"], results);
+    }
+
+    #[test]
+    fn find_should_extract_email_in_parentheses() {
+        let finder = Email::default();
+        let input = "(support@example.com)";
+        let range = finder.find(input).unwrap();
+        assert_eq!("support@example.com", &input[range]);
+    }
+
+    #[test]
+    fn find_should_handle_empty_input() {
+        let finder = Email::default();
+        assert!(finder.find("").is_none());
+    }
+
+    #[test]
+    fn find_should_handle_bare_at() {
+        let finder = Email::default();
+        assert!(finder.find("@").is_none());
+    }
+
+    #[test]
+    fn find_should_skip_invalid_and_find_valid() {
+        let finder = Email::default();
+        let input = "@invalid then real@example.com";
+        let range = finder.find(input).unwrap();
+        assert_eq!("real@example.com", &input[range]);
+    }
+}

--- a/squeeze/env.rs
+++ b/squeeze/env.rs
@@ -1,0 +1,198 @@
+use super::Finder;
+use std::ops::Range;
+
+#[derive(Default)]
+pub struct Env {}
+
+impl Env {
+    fn is_name_start(b: u8) -> bool {
+        b.is_ascii_alphabetic() || b == b'_'
+    }
+
+    fn is_name_char(b: u8) -> bool {
+        b.is_ascii_alphanumeric() || b == b'_'
+    }
+}
+
+impl Finder for Env {
+    fn id(&self) -> &'static str {
+        "env"
+    }
+
+    fn find(&self, s: &str) -> Option<Range<usize>> {
+        let input = s.as_bytes();
+        let mut idx = 0;
+
+        while idx < input.len() {
+            let dollar = idx + input[idx..].iter().position(|&b| b == b'$')?;
+
+            let after = dollar + 1;
+            if after >= input.len() {
+                return None;
+            }
+
+            if input[after] == b'{' {
+                let name_start = after + 1;
+                if name_start < input.len() && Self::is_name_start(input[name_start]) {
+                    let mut name_end = name_start + 1;
+                    while name_end < input.len() && Self::is_name_char(input[name_end]) {
+                        name_end += 1;
+                    }
+                    if name_end < input.len() && input[name_end] == b'}' {
+                        return Some(dollar..name_end + 1);
+                    }
+                }
+                idx = after + 1;
+                continue;
+            }
+
+            if Self::is_name_start(input[after]) {
+                let mut name_end = after + 1;
+                while name_end < input.len() && Self::is_name_char(input[name_end]) {
+                    name_end += 1;
+                }
+                return Some(dollar..name_end);
+            }
+
+            idx = after;
+        }
+
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn id_should_return_env() {
+        let finder = Env::default();
+        assert_eq!("env", finder.id());
+    }
+
+    #[test]
+    fn find_should_extract_simple_var() {
+        let finder = Env::default();
+        let input = "use $HOME for path";
+        let range = finder.find(input).unwrap();
+        assert_eq!("$HOME", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_braced_var() {
+        let finder = Env::default();
+        let input = "use ${HOME} for path";
+        let range = finder.find(input).unwrap();
+        assert_eq!("${HOME}", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_var_with_underscores() {
+        let finder = Env::default();
+        let input = "set $MY_VAR_123 here";
+        let range = finder.find(input).unwrap();
+        assert_eq!("$MY_VAR_123", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_var_starting_with_underscore() {
+        let finder = Env::default();
+        let input = "$_private";
+        let range = finder.find(input).unwrap();
+        assert_eq!("$_private", &input[range]);
+    }
+
+    #[test]
+    fn find_should_reject_dollar_followed_by_digit() {
+        let finder = Env::default();
+        assert!(finder.find("$123").is_none());
+    }
+
+    #[test]
+    fn find_should_reject_bare_dollar() {
+        let finder = Env::default();
+        assert!(finder.find("$ foo").is_none());
+    }
+
+    #[test]
+    fn find_should_reject_dollar_at_end() {
+        let finder = Env::default();
+        assert!(finder.find("cost is $").is_none());
+    }
+
+    #[test]
+    fn find_should_reject_empty_braces() {
+        let finder = Env::default();
+        assert!(finder.find("${} foo").is_none());
+    }
+
+    #[test]
+    fn find_should_reject_unclosed_brace() {
+        let finder = Env::default();
+        assert!(finder.find("${HOME foo").is_none());
+    }
+
+    #[test]
+    fn find_should_reject_brace_with_digit_start() {
+        let finder = Env::default();
+        assert!(finder.find("${123}").is_none());
+    }
+
+    #[test]
+    fn find_should_extract_var_at_start() {
+        let finder = Env::default();
+        let input = "$PATH is set";
+        let range = finder.find(input).unwrap();
+        assert_eq!("$PATH", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_var_at_end() {
+        let finder = Env::default();
+        let input = "see $PATH";
+        let range = finder.find(input).unwrap();
+        assert_eq!("$PATH", &input[range]);
+    }
+
+    #[test]
+    fn find_should_handle_empty_input() {
+        let finder = Env::default();
+        assert!(finder.find("").is_none());
+    }
+
+    #[test]
+    fn find_should_extract_multiple_vars_iteratively() {
+        let finder = Env::default();
+        let input = "$HOME and ${PATH} here";
+
+        let mut results = Vec::new();
+        let mut idx = 0;
+        while idx < input.len() {
+            if let Some(range) = finder.find(&input[idx..]) {
+                results.push(&input[idx + range.start..idx + range.end]);
+                idx += range.end;
+            } else {
+                break;
+            }
+        }
+
+        assert_eq!(vec!["$HOME", "${PATH}"], results);
+    }
+
+    #[test]
+    fn find_should_skip_invalid_and_find_valid() {
+        let finder = Env::default();
+        let input = "$123 then $VALID";
+        let range = finder.find(input).unwrap();
+        assert_eq!("$VALID", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_var_in_quotes() {
+        let finder = Env::default();
+        let input = r#"echo "$HOME""#;
+        let range = finder.find(input).unwrap();
+        assert_eq!("$HOME", &input[range]);
+    }
+}

--- a/squeeze/hash.rs
+++ b/squeeze/hash.rs
@@ -1,0 +1,244 @@
+use super::Finder;
+use std::collections::HashSet;
+use std::ops::Range;
+
+const MD5_LEN: usize = 32;
+const SHA1_LEN: usize = 40;
+const SHA256_LEN: usize = 64;
+const SHA512_LEN: usize = 128;
+
+const ALL_LENGTHS: &[usize] = &[MD5_LEN, SHA1_LEN, SHA256_LEN, SHA512_LEN];
+
+#[derive(Default)]
+pub struct Hash {
+    lengths: HashSet<usize>,
+}
+
+impl Hash {
+    pub fn add_algorithm(&mut self, name: &str) {
+        let len = match name.to_lowercase().as_str() {
+            "md5" => MD5_LEN,
+            "sha1" | "sha-1" => SHA1_LEN,
+            "sha256" | "sha-256" => SHA256_LEN,
+            "sha512" | "sha-512" => SHA512_LEN,
+            _ => return,
+        };
+        self.lengths.insert(len);
+    }
+
+    fn is_target_length(&self, len: usize) -> bool {
+        if self.lengths.is_empty() {
+            ALL_LENGTHS.contains(&len)
+        } else {
+            self.lengths.contains(&len)
+        }
+    }
+
+    fn is_hex(b: u8) -> bool {
+        b.is_ascii_hexdigit()
+    }
+}
+
+impl Finder for Hash {
+    fn id(&self) -> &'static str {
+        "hash"
+    }
+
+    fn find(&self, s: &str) -> Option<Range<usize>> {
+        let input = s.as_bytes();
+        let mut idx = 0;
+
+        while idx < input.len() {
+            if !Self::is_hex(input[idx]) {
+                idx += 1;
+                continue;
+            }
+
+            // Check boundary before
+            if idx > 0 && Self::is_hex(input[idx - 1]) {
+                idx += 1;
+                continue;
+            }
+
+            let start = idx;
+            let mut end = start;
+            while end < input.len() && Self::is_hex(input[end]) {
+                end += 1;
+            }
+
+            let len = end - start;
+
+            // Check boundary after
+            if end < input.len() && Self::is_hex(input[end]) {
+                idx = end + 1;
+                continue;
+            }
+
+            if self.is_target_length(len) {
+                return Some(start..end);
+            }
+
+            idx = end;
+        }
+
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn id_should_return_hash() {
+        let finder = Hash::default();
+        assert_eq!("hash", finder.id());
+    }
+
+    #[test]
+    fn find_should_extract_md5() {
+        let finder = Hash::default();
+        let input = "md5: 5d41402abc4b2a76b9719d911017c592";
+        let range = finder.find(input).unwrap();
+        assert_eq!("5d41402abc4b2a76b9719d911017c592", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_sha1() {
+        let finder = Hash::default();
+        let input = "sha1: 2aae6c35c94fcfb415dbe95f408b9ce91ee846ed";
+        let range = finder.find(input).unwrap();
+        assert_eq!("2aae6c35c94fcfb415dbe95f408b9ce91ee846ed", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_sha256() {
+        let finder = Hash::default();
+        let input = "sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+        let range = finder.find(input).unwrap();
+        assert_eq!(
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            &input[range]
+        );
+    }
+
+    #[test]
+    fn find_should_extract_sha512() {
+        let finder = Hash::default();
+        let input = "sha512: cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e";
+        let range = finder.find(input).unwrap();
+        assert_eq!(128, input[range].len());
+    }
+
+    #[test]
+    fn find_should_extract_uppercase_hash() {
+        let finder = Hash::default();
+        let input = "5D41402ABC4B2A76B9719D911017C592";
+        let range = finder.find(input).unwrap();
+        assert_eq!("5D41402ABC4B2A76B9719D911017C592", &input[range]);
+    }
+
+    #[test]
+    fn find_should_filter_by_algorithm() {
+        let mut finder = Hash::default();
+        finder.add_algorithm("sha256");
+
+        let md5 = "5d41402abc4b2a76b9719d911017c592";
+        assert!(finder.find(md5).is_none());
+
+        let sha256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+        assert!(finder.find(sha256).is_some());
+    }
+
+    #[test]
+    fn find_should_filter_md5_only() {
+        let mut finder = Hash::default();
+        finder.add_algorithm("md5");
+
+        let input = "5d41402abc4b2a76b9719d911017c592";
+        assert!(finder.find(input).is_some());
+
+        let sha1 = "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed";
+        assert!(finder.find(sha1).is_none());
+    }
+
+    #[test]
+    fn find_should_not_match_short_hex() {
+        let finder = Hash::default();
+        assert!(finder.find("deadbeef").is_none());
+    }
+
+    #[test]
+    fn find_should_not_match_within_longer_hex() {
+        let finder = Hash::default();
+        // 33 hex chars — not a valid hash length, and should not partially match
+        let input = "a5d41402abc4b2a76b9719d911017c592";
+        assert!(finder.find(input).is_none());
+    }
+
+    #[test]
+    fn find_should_not_match_with_trailing_hex() {
+        let finder = Hash::default();
+        let input = "5d41402abc4b2a76b9719d911017c592a";
+        assert!(finder.find(input).is_none());
+    }
+
+    #[test]
+    fn find_should_extract_hash_in_text() {
+        let finder = Hash::default();
+        let input = "commit 2aae6c35c94fcfb415dbe95f408b9ce91ee846ed in main";
+        let range = finder.find(input).unwrap();
+        assert_eq!("2aae6c35c94fcfb415dbe95f408b9ce91ee846ed", &input[range]);
+    }
+
+    #[test]
+    fn find_should_handle_empty_input() {
+        let finder = Hash::default();
+        assert!(finder.find("").is_none());
+    }
+
+    #[test]
+    fn find_should_extract_multiple_hashes_iteratively() {
+        let finder = Hash::default();
+        let input = "5d41402abc4b2a76b9719d911017c592 and 2aae6c35c94fcfb415dbe95f408b9ce91ee846ed";
+
+        let mut results = Vec::new();
+        let mut idx = 0;
+        while idx < input.len() {
+            if let Some(range) = finder.find(&input[idx..]) {
+                results.push(&input[idx + range.start..idx + range.end]);
+                idx += range.end;
+            } else {
+                break;
+            }
+        }
+
+        assert_eq!(
+            vec![
+                "5d41402abc4b2a76b9719d911017c592",
+                "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed"
+            ],
+            results
+        );
+    }
+
+    #[test]
+    fn add_algorithm_should_accept_various_names() {
+        let mut finder = Hash::default();
+        finder.add_algorithm("sha-256");
+        assert!(finder.lengths.contains(&64));
+
+        finder.add_algorithm("SHA1");
+        assert!(finder.lengths.contains(&40));
+
+        finder.add_algorithm("SHA-512");
+        assert!(finder.lengths.contains(&128));
+    }
+
+    #[test]
+    fn add_algorithm_should_ignore_unknown() {
+        let mut finder = Hash::default();
+        finder.add_algorithm("blake2");
+        assert!(finder.lengths.is_empty());
+    }
+}

--- a/squeeze/ip.rs
+++ b/squeeze/ip.rs
@@ -1,0 +1,447 @@
+use super::Finder;
+use std::ops::Range;
+
+pub struct Ip {
+    pub ipv4: bool,
+    pub ipv6: bool,
+}
+
+impl Default for Ip {
+    fn default() -> Self {
+        Ip {
+            ipv4: true,
+            ipv6: true,
+        }
+    }
+}
+
+impl Ip {
+    fn try_ipv4(input: &[u8], idx: usize) -> Option<Range<usize>> {
+        if !input[idx].is_ascii_digit() {
+            return None;
+        }
+        // Boundary before: not preceded by digit or dot
+        if idx > 0 && (input[idx - 1].is_ascii_digit() || input[idx - 1] == b'.') {
+            return None;
+        }
+
+        let start = idx;
+        let mut pos = idx;
+
+        for octet_idx in 0..4 {
+            if octet_idx > 0 {
+                if pos >= input.len() || input[pos] != b'.' {
+                    return None;
+                }
+                pos += 1;
+            }
+
+            let octet_start = pos;
+            while pos < input.len() && input[pos].is_ascii_digit() {
+                pos += 1;
+            }
+            let octet_len = pos - octet_start;
+            if octet_len == 0 || octet_len > 3 {
+                return None;
+            }
+
+            // No leading zeros (except "0" itself)
+            if octet_len > 1 && input[octet_start] == b'0' {
+                return None;
+            }
+
+            let octet_str = std::str::from_utf8(&input[octet_start..pos]).ok()?;
+            let value: u16 = octet_str.parse().ok()?;
+            if value > 255 {
+                return None;
+            }
+        }
+
+        // Boundary after: not followed by digit or dot
+        if pos < input.len() && (input[pos].is_ascii_digit() || input[pos] == b'.') {
+            return None;
+        }
+
+        Some(start..pos)
+    }
+
+    fn try_bracketed_ipv6(input: &[u8], idx: usize) -> Option<Range<usize>> {
+        if input[idx] != b'[' {
+            return None;
+        }
+
+        let close = input[idx..].iter().position(|&b| b == b']')?;
+        let close_pos = idx + close;
+        let inner = &input[idx + 1..close_pos];
+
+        if Self::is_valid_ipv6(inner) {
+            Some(idx..close_pos + 1)
+        } else {
+            None
+        }
+    }
+
+    fn try_bare_ipv6(input: &[u8], idx: usize) -> Option<Range<usize>> {
+        // Must start with hex digit or ':'
+        if !input[idx].is_ascii_hexdigit() && input[idx] != b':' {
+            return None;
+        }
+
+        // Boundary before: not preceded by hex digit, colon, or alphanumeric
+        if idx > 0 && (input[idx - 1].is_ascii_alphanumeric() || input[idx - 1] == b':') {
+            return None;
+        }
+
+        let start = idx;
+        let mut end = idx;
+
+        while end < input.len()
+            && (input[end].is_ascii_hexdigit() || input[end] == b':' || input[end] == b'.')
+        {
+            end += 1;
+        }
+
+        // Strip trailing colons
+        while end > start && input[end - 1] == b':' && !(end >= 2 && input[end - 2] == b':') {
+            end -= 1;
+        }
+
+        let candidate = &input[start..end];
+
+        // Must contain at least one colon
+        if !candidate.contains(&b':') {
+            return None;
+        }
+
+        // Boundary after
+        if end < input.len() && (input[end].is_ascii_alphanumeric() || input[end] == b':') {
+            return None;
+        }
+
+        if Self::is_valid_ipv6(candidate) {
+            Some(start..end)
+        } else {
+            None
+        }
+    }
+
+    fn is_valid_ipv6(bytes: &[u8]) -> bool {
+        let s = match std::str::from_utf8(bytes) {
+            Ok(s) => s,
+            Err(_) => return false,
+        };
+
+        // Handle IPv4-mapped IPv6 (e.g., ::ffff:192.168.1.1)
+        if let Some(last_colon) = s.rfind(':') {
+            let suffix = &s[last_colon + 1..];
+            if suffix.contains('.') {
+                let prefix = &s[..last_colon + 1];
+                let prefix_bytes = prefix.as_bytes();
+                // Validate the IPv4 part
+                let parts: Vec<&str> = suffix.split('.').collect();
+                if parts.len() == 4 {
+                    let ipv4_valid = parts.iter().all(|p| {
+                        if p.is_empty() || p.len() > 3 {
+                            return false;
+                        }
+                        if p.len() > 1 && p.starts_with('0') {
+                            return false;
+                        }
+                        p.parse::<u16>().is_ok_and(|v| v <= 255)
+                    });
+                    if ipv4_valid {
+                        // Validate the prefix as IPv6 groups (should end with :)
+                        // Count the groups in prefix
+                        let trimmed = prefix.trim_end_matches(':');
+                        if trimmed.is_empty() {
+                            // Just "::" prefix — valid
+                            return prefix_bytes.windows(2).any(|w| w == b"::");
+                        }
+                        // Validate prefix groups
+                        return Self::validate_ipv6_groups(trimmed, true);
+                    }
+                }
+            }
+        }
+
+        Self::validate_ipv6_groups(s, false)
+    }
+
+    fn validate_ipv6_groups(s: &str, has_ipv4_suffix: bool) -> bool {
+        let max_groups = if has_ipv4_suffix { 6 } else { 8 };
+
+        if s == "::" {
+            return true;
+        }
+
+        let has_double_colon = s.contains("::");
+
+        // Split on :: first
+        if has_double_colon {
+            let parts: Vec<&str> = s.splitn(2, "::").collect();
+            if parts.len() != 2 {
+                return false;
+            }
+
+            let left_groups: Vec<&str> = if parts[0].is_empty() {
+                vec![]
+            } else {
+                parts[0].split(':').collect()
+            };
+
+            let right_groups: Vec<&str> = if parts[1].is_empty() {
+                vec![]
+            } else {
+                parts[1].split(':').collect()
+            };
+
+            let total = left_groups.len() + right_groups.len();
+            if total >= max_groups {
+                return false;
+            }
+
+            left_groups
+                .iter()
+                .chain(right_groups.iter())
+                .all(|g| Self::is_valid_hex_group(g))
+        } else {
+            let groups: Vec<&str> = s.split(':').collect();
+            groups.len() == max_groups && groups.iter().all(|g| Self::is_valid_hex_group(g))
+        }
+    }
+
+    fn is_valid_hex_group(g: &str) -> bool {
+        !g.is_empty() && g.len() <= 4 && g.bytes().all(|b| b.is_ascii_hexdigit())
+    }
+}
+
+impl Finder for Ip {
+    fn id(&self) -> &'static str {
+        "ip"
+    }
+
+    fn find(&self, s: &str) -> Option<Range<usize>> {
+        let input = s.as_bytes();
+        let mut idx = 0;
+
+        while idx < input.len() {
+            if self.ipv6 {
+                if input[idx] == b'[' {
+                    if let Some(range) = Self::try_bracketed_ipv6(input, idx) {
+                        return Some(range);
+                    }
+                }
+
+                if input[idx].is_ascii_hexdigit() || input[idx] == b':' {
+                    if let Some(range) = Self::try_bare_ipv6(input, idx) {
+                        return Some(range);
+                    }
+                }
+            }
+
+            if self.ipv4 && input[idx].is_ascii_digit() {
+                if let Some(range) = Self::try_ipv4(input, idx) {
+                    return Some(range);
+                }
+            }
+
+            idx += 1;
+        }
+
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn id_should_return_ip() {
+        let finder = Ip::default();
+        assert_eq!("ip", finder.id());
+    }
+
+    // IPv4 tests
+    #[test]
+    fn find_should_extract_ipv4() {
+        let finder = Ip::default();
+        let input = "server at 192.168.1.1 running";
+        let range = finder.find(input).unwrap();
+        assert_eq!("192.168.1.1", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_ipv4_at_start() {
+        let finder = Ip::default();
+        let input = "10.0.0.1 is gateway";
+        let range = finder.find(input).unwrap();
+        assert_eq!("10.0.0.1", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_ipv4_at_end() {
+        let finder = Ip::default();
+        let input = "connect to 172.16.0.1";
+        let range = finder.find(input).unwrap();
+        assert_eq!("172.16.0.1", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_localhost() {
+        let finder = Ip::default();
+        let input = "127.0.0.1";
+        let range = finder.find(input).unwrap();
+        assert_eq!("127.0.0.1", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_all_zeros() {
+        let finder = Ip::default();
+        let input = "0.0.0.0";
+        let range = finder.find(input).unwrap();
+        assert_eq!("0.0.0.0", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_max_values() {
+        let finder = Ip::default();
+        let input = "255.255.255.255";
+        let range = finder.find(input).unwrap();
+        assert_eq!("255.255.255.255", &input[range]);
+    }
+
+    #[test]
+    fn find_should_reject_octet_over_255() {
+        let finder = Ip::default();
+        assert!(finder.find("256.1.1.1").is_none());
+    }
+
+    #[test]
+    fn find_should_reject_three_octets() {
+        let finder = Ip::default();
+        assert!(finder.find("192.168.1 only").is_none());
+    }
+
+    #[test]
+    fn find_should_reject_five_octets() {
+        let finder = Ip::default();
+        assert!(finder.find("192.168.1.1.1").is_none());
+    }
+
+    #[test]
+    fn find_should_reject_leading_zeros() {
+        let finder = Ip::default();
+        assert!(finder.find("192.168.01.1").is_none());
+    }
+
+    #[test]
+    fn find_should_reject_preceded_by_digit() {
+        let finder = Ip::default();
+        assert!(finder.find("9192.168.1.1").is_none());
+    }
+
+    // IPv6 tests
+    #[test]
+    fn find_should_extract_bracketed_ipv6() {
+        let finder = Ip::default();
+        let input = "connect to [::1] now";
+        let range = finder.find(input).unwrap();
+        assert_eq!("[::1]", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_full_ipv6() {
+        let finder = Ip::default();
+        let input = "addr 2001:0db8:85a3:0000:0000:8a2e:0370:7334 here";
+        let range = finder.find(input).unwrap();
+        assert_eq!("2001:0db8:85a3:0000:0000:8a2e:0370:7334", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_compressed_ipv6() {
+        let finder = Ip::default();
+        let input = "addr 2001:db8::1 here";
+        let range = finder.find(input).unwrap();
+        assert_eq!("2001:db8::1", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_loopback_ipv6() {
+        let finder = Ip::default();
+        let input = "[::1]";
+        let range = finder.find(input).unwrap();
+        assert_eq!("[::1]", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_bare_double_colon() {
+        let finder = Ip::default();
+        let input = "addr :: here";
+        let range = finder.find(input).unwrap();
+        assert_eq!("::", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_ipv6_with_prefix_groups() {
+        let finder = Ip::default();
+        let input = "fe80::1";
+        let range = finder.find(input).unwrap();
+        assert_eq!("fe80::1", &input[range]);
+    }
+
+    // Filter tests
+    #[test]
+    fn find_should_only_match_ipv4_when_configured() {
+        let finder = Ip {
+            ipv4: true,
+            ipv6: false,
+        };
+        let input = "192.168.1.1 and [::1]";
+        let range = finder.find(input).unwrap();
+        assert_eq!("192.168.1.1", &input[range]);
+    }
+
+    #[test]
+    fn find_should_only_match_ipv6_when_configured() {
+        let finder = Ip {
+            ipv4: false,
+            ipv6: true,
+        };
+        let input = "192.168.1.1 and [::1]";
+        let range = finder.find(input).unwrap();
+        assert_eq!("[::1]", &input[range]);
+    }
+
+    // Multiple
+    #[test]
+    fn find_should_extract_multiple_ips_iteratively() {
+        let finder = Ip::default();
+        let input = "10.0.0.1 and 10.0.0.2";
+
+        let mut results = Vec::new();
+        let mut idx = 0;
+        while idx < input.len() {
+            if let Some(range) = finder.find(&input[idx..]) {
+                results.push(&input[idx + range.start..idx + range.end]);
+                idx += range.end;
+            } else {
+                break;
+            }
+        }
+
+        assert_eq!(vec!["10.0.0.1", "10.0.0.2"], results);
+    }
+
+    #[test]
+    fn find_should_handle_empty_input() {
+        let finder = Ip::default();
+        assert!(finder.find("").is_none());
+    }
+
+    #[test]
+    fn find_should_handle_no_ip() {
+        let finder = Ip::default();
+        assert!(finder.find("just some text").is_none());
+    }
+}

--- a/squeeze/json.rs
+++ b/squeeze/json.rs
@@ -1,0 +1,250 @@
+use super::Finder;
+use std::ops::Range;
+
+const MAX_DEPTH: usize = 256;
+
+#[derive(Default)]
+pub struct Json {}
+
+impl Json {
+    fn try_extract(input: &[u8], start: usize) -> Option<Range<usize>> {
+        if !matches!(input[start], b'{' | b'[') {
+            return None;
+        }
+
+        let mut depth: usize = 1;
+        let mut pos = start + 1;
+
+        while pos < input.len() && depth > 0 {
+            match input[pos] {
+                b'"' => {
+                    pos += 1;
+                    while pos < input.len() {
+                        if input[pos] == b'\\' {
+                            pos += 2;
+                            continue;
+                        }
+                        if input[pos] == b'"' {
+                            pos += 1;
+                            break;
+                        }
+                        pos += 1;
+                    }
+                    continue;
+                }
+                b'{' | b'[' => {
+                    depth += 1;
+                    if depth > MAX_DEPTH {
+                        return None;
+                    }
+                }
+                b'}' | b']' => {
+                    depth -= 1;
+                }
+                _ => {}
+            }
+            pos += 1;
+        }
+
+        if depth == 0 {
+            Some(start..pos)
+        } else {
+            None
+        }
+    }
+}
+
+impl Finder for Json {
+    fn id(&self) -> &'static str {
+        "json"
+    }
+
+    fn find(&self, s: &str) -> Option<Range<usize>> {
+        let input = s.as_bytes();
+        let mut idx = 0;
+
+        while idx < input.len() {
+            if input[idx] == b'{' || input[idx] == b'[' {
+                if let Some(range) = Self::try_extract(input, idx) {
+                    return Some(range);
+                }
+            }
+            idx += 1;
+        }
+
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn id_should_return_json() {
+        let finder = Json::default();
+        assert_eq!("json", finder.id());
+    }
+
+    // Objects
+    #[test]
+    fn find_should_extract_simple_object() {
+        let finder = Json::default();
+        let input = r#"data: {"key": "value"}"#;
+        let range = finder.find(input).unwrap();
+        assert_eq!(r#"{"key": "value"}"#, &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_nested_object() {
+        let finder = Json::default();
+        let input = r#"{"a": {"b": "c"}}"#;
+        let range = finder.find(input).unwrap();
+        assert_eq!(r#"{"a": {"b": "c"}}"#, &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_object_with_array() {
+        let finder = Json::default();
+        let input = r#"{"items": [1, 2, 3]}"#;
+        let range = finder.find(input).unwrap();
+        assert_eq!(r#"{"items": [1, 2, 3]}"#, &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_empty_object() {
+        let finder = Json::default();
+        let input = "result: {}";
+        let range = finder.find(input).unwrap();
+        assert_eq!("{}", &input[range]);
+    }
+
+    // Arrays
+    #[test]
+    fn find_should_extract_simple_array() {
+        let finder = Json::default();
+        let input = "data: [1, 2, 3]";
+        let range = finder.find(input).unwrap();
+        assert_eq!("[1, 2, 3]", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_nested_array() {
+        let finder = Json::default();
+        let input = "[[1, 2], [3, 4]]";
+        let range = finder.find(input).unwrap();
+        assert_eq!("[[1, 2], [3, 4]]", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_empty_array() {
+        let finder = Json::default();
+        let input = "items: []";
+        let range = finder.find(input).unwrap();
+        assert_eq!("[]", &input[range]);
+    }
+
+    // String handling
+    #[test]
+    fn find_should_handle_escaped_quotes() {
+        let finder = Json::default();
+        let input = r#"{"msg": "say \"hello\""}"#;
+        let range = finder.find(input).unwrap();
+        assert_eq!(r#"{"msg": "say \"hello\""}"#, &input[range]);
+    }
+
+    #[test]
+    fn find_should_handle_braces_in_strings() {
+        let finder = Json::default();
+        let input = r#"{"template": "{name}"}"#;
+        let range = finder.find(input).unwrap();
+        assert_eq!(r#"{"template": "{name}"}"#, &input[range]);
+    }
+
+    #[test]
+    fn find_should_handle_brackets_in_strings() {
+        let finder = Json::default();
+        let input = r#"{"pattern": "[a-z]"}"#;
+        let range = finder.find(input).unwrap();
+        assert_eq!(r#"{"pattern": "[a-z]"}"#, &input[range]);
+    }
+
+    #[test]
+    fn find_should_handle_escaped_backslash() {
+        let finder = Json::default();
+        let input = r#"{"path": "C:\\Users\\foo"}"#;
+        let range = finder.find(input).unwrap();
+        assert_eq!(r#"{"path": "C:\\Users\\foo"}"#, &input[range]);
+    }
+
+    // Edge cases
+    #[test]
+    fn find_should_reject_unclosed_object() {
+        let finder = Json::default();
+        assert!(finder.find(r#"{"key": "value""#).is_none());
+    }
+
+    #[test]
+    fn find_should_reject_unclosed_array() {
+        let finder = Json::default();
+        assert!(finder.find("[1, 2, 3").is_none());
+    }
+
+    #[test]
+    fn find_should_handle_empty_input() {
+        let finder = Json::default();
+        assert!(finder.find("").is_none());
+    }
+
+    #[test]
+    fn find_should_extract_json_from_log_line() {
+        let finder = Json::default();
+        let input = r#"2024-01-15 INFO: {"event": "login", "user": "alice"} processed"#;
+        let range = finder.find(input).unwrap();
+        assert_eq!(r#"{"event": "login", "user": "alice"}"#, &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_first_json_object() {
+        let finder = Json::default();
+        let input = r#"{"a": 1} and {"b": 2}"#;
+        let range = finder.find(input).unwrap();
+        assert_eq!(r#"{"a": 1}"#, &input[range]);
+    }
+
+    // Multiple
+    #[test]
+    fn find_should_extract_multiple_json_iteratively() {
+        let finder = Json::default();
+        let input = r#"{"a": 1} and [2, 3]"#;
+
+        let mut results = Vec::new();
+        let mut idx = 0;
+        while idx < input.len() {
+            if let Some(range) = finder.find(&input[idx..]) {
+                results.push(&input[idx + range.start..idx + range.end]);
+                idx += range.end;
+            } else {
+                break;
+            }
+        }
+
+        assert_eq!(vec![r#"{"a": 1}"#, "[2, 3]"], results);
+    }
+
+    #[test]
+    fn find_should_handle_deeply_nested() {
+        let finder = Json::default();
+        let input = r#"{"a": {"b": {"c": {"d": "deep"}}}}"#;
+        let range = finder.find(input).unwrap();
+        assert_eq!(input, &input[range]);
+    }
+
+    #[test]
+    fn find_should_skip_unclosed_and_find_next() {
+        let finder = Json::default();
+        let input = r#"{unclosed and {"valid": true}"#;
+        let range = finder.find(input).unwrap();
+        assert_eq!(r#"{"valid": true}"#, &input[range]);
+    }
+}

--- a/squeeze/jwt.rs
+++ b/squeeze/jwt.rs
@@ -100,7 +100,9 @@ impl Finder for Jwt {
                 };
 
                 // Boundary after: not followed by base64url chars or dot
-                if sig_end < input.len() && (Self::is_base64url(input[sig_end]) || input[sig_end] == b'.') {
+                if sig_end < input.len()
+                    && (Self::is_base64url(input[sig_end]) || input[sig_end] == b'.')
+                {
                     idx += 1;
                     continue;
                 }
@@ -164,7 +166,9 @@ mod tests {
     #[test]
     fn find_should_reject_two_segments() {
         let finder = Jwt::default();
-        assert!(finder.find("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0").is_none());
+        assert!(finder
+            .find("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0")
+            .is_none());
     }
 
     #[test]

--- a/squeeze/jwt.rs
+++ b/squeeze/jwt.rs
@@ -1,0 +1,213 @@
+use super::Finder;
+use std::ops::Range;
+
+#[derive(Default)]
+pub struct Jwt {}
+
+impl Jwt {
+    fn is_base64url(b: u8) -> bool {
+        b.is_ascii_alphanumeric() || b == b'+' || b == b'/' || b == b'-' || b == b'_' || b == b'='
+    }
+
+    fn is_base64url_no_pad(b: u8) -> bool {
+        b.is_ascii_alphanumeric() || b == b'+' || b == b'/' || b == b'-' || b == b'_'
+    }
+
+    fn read_segment(input: &[u8], start: usize) -> Option<usize> {
+        let mut pos = start;
+        if pos >= input.len() || !Self::is_base64url_no_pad(input[pos]) {
+            return None;
+        }
+        while pos < input.len() && Self::is_base64url(input[pos]) {
+            pos += 1;
+        }
+        // Minimum segment length for a valid JWT part (header is at least ~20 chars base64)
+        if pos - start < 4 {
+            return None;
+        }
+        Some(pos)
+    }
+
+    fn looks_like_jwt_header(input: &[u8], start: usize, end: usize) -> bool {
+        // JWT header is base64url-encoded JSON containing "alg"
+        // The base64 of {"alg": always starts with "eyJ"
+        end - start >= 4
+            && input[start] == b'e'
+            && input[start + 1] == b'y'
+            && input[start + 2] == b'J'
+    }
+}
+
+impl Finder for Jwt {
+    fn id(&self) -> &'static str {
+        "jwt"
+    }
+
+    fn find(&self, s: &str) -> Option<Range<usize>> {
+        let input = s.as_bytes();
+        let mut idx = 0;
+
+        while idx < input.len() {
+            // JWT headers always start with "eyJ" (base64 of '{"')
+            if input[idx] == b'e' {
+                // Boundary before
+                if idx > 0 && Self::is_base64url(input[idx - 1]) {
+                    idx += 1;
+                    continue;
+                }
+
+                let header_end = match Self::read_segment(input, idx) {
+                    Some(end) => end,
+                    None => {
+                        idx += 1;
+                        continue;
+                    }
+                };
+
+                if !Self::looks_like_jwt_header(input, idx, header_end) {
+                    idx += 1;
+                    continue;
+                }
+
+                // First dot
+                if header_end >= input.len() || input[header_end] != b'.' {
+                    idx += 1;
+                    continue;
+                }
+
+                // Payload
+                let payload_end = match Self::read_segment(input, header_end + 1) {
+                    Some(end) => end,
+                    None => {
+                        idx += 1;
+                        continue;
+                    }
+                };
+
+                // Second dot
+                if payload_end >= input.len() || input[payload_end] != b'.' {
+                    idx += 1;
+                    continue;
+                }
+
+                // Signature
+                let sig_end = match Self::read_segment(input, payload_end + 1) {
+                    Some(end) => end,
+                    None => {
+                        idx += 1;
+                        continue;
+                    }
+                };
+
+                // Boundary after: not followed by base64url chars or dot
+                if sig_end < input.len() && (Self::is_base64url(input[sig_end]) || input[sig_end] == b'.') {
+                    idx += 1;
+                    continue;
+                }
+
+                return Some(idx..sig_end);
+            }
+            idx += 1;
+        }
+
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A realistic JWT (HS256): header.payload.signature
+    const JWT_HS256: &str = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+
+    // RS256 JWT (longer signature)
+    const JWT_RS256: &str = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.NHVaYe26MbtOYhSKkoKYdFVomg4i8ZJd8_5RU8VuLeas";
+
+    #[test]
+    fn id_should_return_jwt() {
+        let finder = Jwt::default();
+        assert_eq!("jwt", finder.id());
+    }
+
+    #[test]
+    fn find_should_extract_jwt() {
+        let finder = Jwt::default();
+        let input = format!("token: {}", JWT_HS256);
+        let range = finder.find(&input).unwrap();
+        assert_eq!(JWT_HS256, &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_jwt_at_start() {
+        let finder = Jwt::default();
+        let input = format!("{} is the token", JWT_HS256);
+        let range = finder.find(&input).unwrap();
+        assert_eq!(JWT_HS256, &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_rs256_jwt() {
+        let finder = Jwt::default();
+        let range = finder.find(JWT_RS256).unwrap();
+        assert_eq!(JWT_RS256, &JWT_RS256[range]);
+    }
+
+    #[test]
+    fn find_should_extract_jwt_in_text() {
+        let finder = Jwt::default();
+        let input = format!("Authorization: Bearer {} end", JWT_HS256);
+        let range = finder.find(&input).unwrap();
+        assert_eq!(JWT_HS256, &input[range]);
+    }
+
+    #[test]
+    fn find_should_reject_two_segments() {
+        let finder = Jwt::default();
+        assert!(finder.find("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0").is_none());
+    }
+
+    #[test]
+    fn find_should_reject_non_eyj_prefix() {
+        let finder = Jwt::default();
+        assert!(finder.find("abc.def.ghi").is_none());
+    }
+
+    #[test]
+    fn find_should_handle_empty_input() {
+        let finder = Jwt::default();
+        assert!(finder.find("").is_none());
+    }
+
+    #[test]
+    fn find_should_reject_preceded_by_alphanumeric() {
+        let finder = Jwt::default();
+        let input = format!("x{}", JWT_HS256);
+        assert!(finder.find(&input).is_none());
+    }
+
+    #[test]
+    fn find_should_extract_multiple_jwts_iteratively() {
+        let finder = Jwt::default();
+        let input = format!("{} and {}", JWT_HS256, JWT_RS256);
+
+        let mut results = Vec::new();
+        let mut idx = 0;
+        while idx < input.len() {
+            if let Some(range) = finder.find(&input[idx..]) {
+                results.push(input[idx + range.start..idx + range.end].to_string());
+                idx += range.end;
+            } else {
+                break;
+            }
+        }
+
+        assert_eq!(vec![JWT_HS256, JWT_RS256], results);
+    }
+
+    #[test]
+    fn find_should_reject_short_segments() {
+        let finder = Jwt::default();
+        assert!(finder.find("eyJ.ab.cd").is_none());
+    }
+}

--- a/squeeze/lib.rs
+++ b/squeeze/lib.rs
@@ -5,6 +5,8 @@
 //! This crate provides finders for extracting structured data from text:
 //! - [`uri::URI`] - Extract URIs/URLs/URNs as defined by [RFC 3986](https://tools.ietf.org/html/rfc3986/)
 //! - [`codetag::Codetag`] - Extract codetags (TODO, FIXME, etc.) as defined by [PEP 350](https://www.python.org/dev/peps/pep-0350/)
+//! - [`email::Email`] - Extract email addresses
+//! - [`path::Path`] - Extract file paths (absolute, relative, and home-relative)
 //! - [`mirror::Mirror`] - A passthrough finder that returns the entire input
 //!
 //! ## Example
@@ -21,7 +23,9 @@
 //! ```
 
 pub mod codetag;
+pub mod email;
 pub mod mirror;
+pub mod path;
 pub mod uri;
 
 use std::ops::Range;

--- a/squeeze/lib.rs
+++ b/squeeze/lib.rs
@@ -5,8 +5,16 @@
 //! This crate provides finders for extracting structured data from text:
 //! - [`uri::URI`] - Extract URIs/URLs/URNs as defined by [RFC 3986](https://tools.ietf.org/html/rfc3986/)
 //! - [`codetag::Codetag`] - Extract codetags (TODO, FIXME, etc.) as defined by [PEP 350](https://www.python.org/dev/peps/pep-0350/)
+//! - [`color::Color`] - Extract colors (hex, rgb, hsl)
 //! - [`email::Email`] - Extract email addresses
+//! - [`env::Env`] - Extract environment variable references
+//! - [`hash::Hash`] - Extract hashes (MD5, SHA-1, SHA-256, SHA-512)
+//! - [`ip::Ip`] - Extract IP addresses (IPv4, IPv6)
+//! - [`json::Json`] - Extract JSON objects and arrays
 //! - [`path::Path`] - Extract file paths (absolute, relative, and home-relative)
+//! - [`phone::Phone`] - Extract phone numbers
+//! - [`semver::Semver`] - Extract semantic versions
+//! - [`uuid::Uuid`] - Extract UUIDs
 //! - [`mirror::Mirror`] - A passthrough finder that returns the entire input
 //!
 //! ## Example
@@ -23,10 +31,18 @@
 //! ```
 
 pub mod codetag;
+pub mod color;
 pub mod email;
+pub mod env;
+pub mod hash;
+pub mod ip;
+pub mod json;
 pub mod mirror;
 pub mod path;
+pub mod phone;
+pub mod semver;
 pub mod uri;
+pub mod uuid;
 
 use std::ops::Range;
 

--- a/squeeze/lib.rs
+++ b/squeeze/lib.rs
@@ -4,13 +4,17 @@
 //!
 //! This crate provides finders for extracting structured data from text:
 //! - [`uri::URI`] - Extract URIs/URLs/URNs as defined by [RFC 3986](https://tools.ietf.org/html/rfc3986/)
+//! - [`cidr::Cidr`] - Extract CIDR notation (IPv4/IPv6 network ranges)
 //! - [`codetag::Codetag`] - Extract codetags (TODO, FIXME, etc.) as defined by [PEP 350](https://www.python.org/dev/peps/pep-0350/)
 //! - [`color::Color`] - Extract colors (hex, rgb, hsl)
+//! - [`datetime::Datetime`] - Extract ISO 8601 datetimes
 //! - [`email::Email`] - Extract email addresses
 //! - [`env::Env`] - Extract environment variable references
 //! - [`hash::Hash`] - Extract hashes (MD5, SHA-1, SHA-256, SHA-512)
 //! - [`ip::Ip`] - Extract IP addresses (IPv4, IPv6)
 //! - [`json::Json`] - Extract JSON objects and arrays
+//! - [`jwt::Jwt`] - Extract JSON Web Tokens
+//! - [`mac::Mac`] - Extract MAC addresses
 //! - [`path::Path`] - Extract file paths (absolute, relative, and home-relative)
 //! - [`phone::Phone`] - Extract phone numbers
 //! - [`semver::Semver`] - Extract semantic versions
@@ -30,13 +34,17 @@
 //! }
 //! ```
 
+pub mod cidr;
 pub mod codetag;
 pub mod color;
+pub mod datetime;
 pub mod email;
 pub mod env;
 pub mod hash;
 pub mod ip;
 pub mod json;
+pub mod jwt;
+pub mod mac;
 pub mod mirror;
 pub mod path;
 pub mod phone;

--- a/squeeze/mac.rs
+++ b/squeeze/mac.rs
@@ -1,0 +1,251 @@
+use super::Finder;
+use std::ops::Range;
+
+#[derive(Default)]
+pub struct Mac {}
+
+impl Mac {
+    fn is_hex(b: u8) -> bool {
+        b.is_ascii_hexdigit()
+    }
+
+    fn try_mac_colon(input: &[u8], idx: usize) -> Option<Range<usize>> {
+        // AA:BB:CC:DD:EE:FF (17 chars)
+        Self::try_mac_separated(input, idx, b':')
+    }
+
+    fn try_mac_dash(input: &[u8], idx: usize) -> Option<Range<usize>> {
+        // AA-BB-CC-DD-EE-FF (17 chars)
+        Self::try_mac_separated(input, idx, b'-')
+    }
+
+    fn try_mac_separated(input: &[u8], idx: usize, sep: u8) -> Option<Range<usize>> {
+        if idx + 17 > input.len() {
+            return None;
+        }
+
+        for group in 0..6 {
+            let pos = idx + group * 3;
+            if group > 0 && input[pos - 1] != sep {
+                return None;
+            }
+            if !Self::is_hex(input[pos]) || !Self::is_hex(input[pos + 1]) {
+                return None;
+            }
+        }
+
+        let end = idx + 17;
+
+        // Boundary after: not followed by hex digit or separator
+        if end < input.len() && (Self::is_hex(input[end]) || input[end] == sep) {
+            return None;
+        }
+
+        Some(idx..end)
+    }
+
+    fn try_mac_dot(input: &[u8], idx: usize) -> Option<Range<usize>> {
+        // AABB.CCDD.EEFF (14 chars)
+        if idx + 14 > input.len() {
+            return None;
+        }
+
+        for group in 0..3 {
+            let pos = idx + group * 5;
+            if group > 0 && input[pos - 1] != b'.' {
+                return None;
+            }
+            for i in 0..4 {
+                if !Self::is_hex(input[pos + i]) {
+                    return None;
+                }
+            }
+        }
+
+        let end = idx + 14;
+
+        // Boundary after: not followed by hex digit or dot
+        if end < input.len() && (Self::is_hex(input[end]) || input[end] == b'.') {
+            return None;
+        }
+
+        Some(idx..end)
+    }
+}
+
+impl Finder for Mac {
+    fn id(&self) -> &'static str {
+        "mac"
+    }
+
+    fn find(&self, s: &str) -> Option<Range<usize>> {
+        let input = s.as_bytes();
+        let mut idx = 0;
+
+        while idx < input.len() {
+            if Self::is_hex(input[idx]) {
+                // Boundary before: not preceded by hex digit, colon, dash, or dot
+                if idx > 0
+                    && (Self::is_hex(input[idx - 1])
+                        || input[idx - 1] == b':'
+                        || input[idx - 1] == b'-'
+                        || input[idx - 1] == b'.')
+                {
+                    idx += 1;
+                    continue;
+                }
+
+                if let Some(range) = Self::try_mac_colon(input, idx) {
+                    return Some(range);
+                }
+                if let Some(range) = Self::try_mac_dash(input, idx) {
+                    return Some(range);
+                }
+                if let Some(range) = Self::try_mac_dot(input, idx) {
+                    return Some(range);
+                }
+            }
+            idx += 1;
+        }
+
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn id_should_return_mac() {
+        let finder = Mac::default();
+        assert_eq!("mac", finder.id());
+    }
+
+    #[test]
+    fn find_should_extract_colon_separated() {
+        let finder = Mac::default();
+        let input = "interface: 00:1A:2B:3C:4D:5E";
+        let range = finder.find(input).unwrap();
+        assert_eq!("00:1A:2B:3C:4D:5E", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_dash_separated() {
+        let finder = Mac::default();
+        let input = "interface: 00-1A-2B-3C-4D-5E";
+        let range = finder.find(input).unwrap();
+        assert_eq!("00-1A-2B-3C-4D-5E", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_dot_separated() {
+        let finder = Mac::default();
+        let input = "interface: 001A.2B3C.4D5E";
+        let range = finder.find(input).unwrap();
+        assert_eq!("001A.2B3C.4D5E", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_lowercase() {
+        let finder = Mac::default();
+        let input = "aa:bb:cc:dd:ee:ff";
+        let range = finder.find(input).unwrap();
+        assert_eq!("aa:bb:cc:dd:ee:ff", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_uppercase() {
+        let finder = Mac::default();
+        let input = "AA:BB:CC:DD:EE:FF";
+        let range = finder.find(input).unwrap();
+        assert_eq!("AA:BB:CC:DD:EE:FF", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_mac_in_text() {
+        let finder = Mac::default();
+        let input = "device 00:1A:2B:3C:4D:5E connected";
+        let range = finder.find(input).unwrap();
+        assert_eq!("00:1A:2B:3C:4D:5E", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_mac_at_start() {
+        let finder = Mac::default();
+        let input = "00:1A:2B:3C:4D:5E is the address";
+        let range = finder.find(input).unwrap();
+        assert_eq!("00:1A:2B:3C:4D:5E", &input[range]);
+    }
+
+    #[test]
+    fn find_should_reject_too_short() {
+        let finder = Mac::default();
+        assert!(finder.find("00:1A:2B:3C:4D").is_none());
+    }
+
+    #[test]
+    fn find_should_reject_non_hex() {
+        let finder = Mac::default();
+        assert!(finder.find("00:1A:2B:3C:4D:5G").is_none());
+    }
+
+    #[test]
+    fn find_should_reject_mixed_separators() {
+        let finder = Mac::default();
+        assert!(finder.find("00:1A-2B:3C-4D:5E").is_none());
+    }
+
+    #[test]
+    fn find_should_not_match_within_longer_hex() {
+        let finder = Mac::default();
+        assert!(finder.find("ff00:1A:2B:3C:4D:5E").is_none());
+    }
+
+    #[test]
+    fn find_should_not_match_with_trailing_hex() {
+        let finder = Mac::default();
+        assert!(finder.find("00:1A:2B:3C:4D:5Eff").is_none());
+    }
+
+    #[test]
+    fn find_should_handle_empty_input() {
+        let finder = Mac::default();
+        assert!(finder.find("").is_none());
+    }
+
+    #[test]
+    fn find_should_extract_multiple_macs_iteratively() {
+        let finder = Mac::default();
+        let input = "00:1A:2B:3C:4D:5E and AA:BB:CC:DD:EE:FF";
+
+        let mut results = Vec::new();
+        let mut idx = 0;
+        while idx < input.len() {
+            if let Some(range) = finder.find(&input[idx..]) {
+                results.push(&input[idx + range.start..idx + range.end]);
+                idx += range.end;
+            } else {
+                break;
+            }
+        }
+
+        assert_eq!(vec!["00:1A:2B:3C:4D:5E", "AA:BB:CC:DD:EE:FF"], results);
+    }
+
+    #[test]
+    fn find_should_extract_broadcast_mac() {
+        let finder = Mac::default();
+        let input = "FF:FF:FF:FF:FF:FF";
+        let range = finder.find(input).unwrap();
+        assert_eq!("FF:FF:FF:FF:FF:FF", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_zero_mac() {
+        let finder = Mac::default();
+        let input = "00:00:00:00:00:00";
+        let range = finder.find(input).unwrap();
+        assert_eq!("00:00:00:00:00:00", &input[range]);
+    }
+}

--- a/squeeze/path.rs
+++ b/squeeze/path.rs
@@ -40,10 +40,11 @@ impl Path {
                         idx += 1;
                         continue;
                     }
-                    if idx == 0 || Self::is_boundary(input[idx - 1]) {
-                        if idx + 1 < input.len() && !input[idx + 1].is_ascii_whitespace() {
-                            return Some((idx, 1));
-                        }
+                    if (idx == 0 || Self::is_boundary(input[idx - 1]))
+                        && idx + 1 < input.len()
+                        && !input[idx + 1].is_ascii_whitespace()
+                    {
+                        return Some((idx, 1));
                     }
                     idx += 1;
                 }

--- a/squeeze/path.rs
+++ b/squeeze/path.rs
@@ -1,0 +1,333 @@
+use super::Finder;
+use std::ops::Range;
+
+#[derive(Default)]
+pub struct Path {}
+
+impl Path {
+    fn is_boundary(b: u8) -> bool {
+        b.is_ascii_whitespace()
+            || matches!(b, b'(' | b'[' | b'{' | b'<' | b'"' | b'\'' | b'`')
+    }
+
+    fn find_prefix(&self, input: &[u8], from: usize) -> Option<(usize, usize)> {
+        let mut idx = from;
+        while idx < input.len() {
+            match input[idx] {
+                b'~' if idx + 1 < input.len() && input[idx + 1] == b'/' => {
+                    if idx == 0 || Self::is_boundary(input[idx - 1]) {
+                        return Some((idx, 2));
+                    }
+                    idx += 2;
+                }
+                b'.' => {
+                    if idx + 2 < input.len()
+                        && input[idx + 1] == b'.'
+                        && input[idx + 2] == b'/'
+                        && (idx == 0 || Self::is_boundary(input[idx - 1]))
+                    {
+                        return Some((idx, 3));
+                    }
+                    if idx + 1 < input.len()
+                        && input[idx + 1] == b'/'
+                        && (idx == 0 || Self::is_boundary(input[idx - 1]))
+                    {
+                        return Some((idx, 2));
+                    }
+                    idx += 1;
+                }
+                b'/' => {
+                    if idx > 0 && input[idx - 1] == b':' {
+                        idx += 1;
+                        continue;
+                    }
+                    if idx == 0 || Self::is_boundary(input[idx - 1]) {
+                        if idx + 1 < input.len() && !input[idx + 1].is_ascii_whitespace() {
+                            return Some((idx, 1));
+                        }
+                    }
+                    idx += 1;
+                }
+                _ => {
+                    idx += 1;
+                }
+            }
+        }
+        None
+    }
+}
+
+impl Finder for Path {
+    fn id(&self) -> &'static str {
+        "path"
+    }
+
+    fn find(&self, s: &str) -> Option<Range<usize>> {
+        let input = s.as_bytes();
+        let mut search_from = 0;
+
+        while search_from < input.len() {
+            let (start, prefix_len) = self.find_prefix(input, search_from)?;
+
+            let mut end = start + prefix_len;
+            while end < input.len() && !input[end].is_ascii_whitespace() {
+                end += 1;
+            }
+
+            // Strip trailing punctuation that's likely sentence-level, not path-level
+            while end > start + prefix_len
+                && matches!(
+                    input[end - 1],
+                    b',' | b';' | b')' | b']' | b'}' | b'>' | b'\'' | b'"' | b'`'
+                )
+            {
+                end -= 1;
+            }
+            // Strip trailing colons (but `:digits` line references are kept because
+            // the colon won't be trailing — it's followed by digits)
+            while end > start + prefix_len && input[end - 1] == b':' {
+                end -= 1;
+            }
+            // Strip trailing periods (sentence endings)
+            while end > start + prefix_len && input[end - 1] == b'.' {
+                end -= 1;
+            }
+
+            if end > start + prefix_len {
+                return Some(start..end);
+            }
+
+            search_from = start + 1;
+        }
+
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn id_should_return_path() {
+        let finder = Path::default();
+        assert_eq!("path", finder.id());
+    }
+
+    // Absolute paths
+    #[test]
+    fn find_should_extract_absolute_path() {
+        let finder = Path::default();
+        let input = "see /etc/hosts for details";
+        let range = finder.find(input).unwrap();
+        assert_eq!("/etc/hosts", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_deep_absolute_path() {
+        let finder = Path::default();
+        let input = "binary at /usr/local/bin/squeeze";
+        let range = finder.find(input).unwrap();
+        assert_eq!("/usr/local/bin/squeeze", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_absolute_path_at_start() {
+        let finder = Path::default();
+        let input = "/var/log/syslog contains errors";
+        let range = finder.find(input).unwrap();
+        assert_eq!("/var/log/syslog", &input[range]);
+    }
+
+    // Relative paths
+    #[test]
+    fn find_should_extract_relative_path() {
+        let finder = Path::default();
+        let input = "edit ./src/main.rs to fix it";
+        let range = finder.find(input).unwrap();
+        assert_eq!("./src/main.rs", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_parent_relative_path() {
+        let finder = Path::default();
+        let input = "see ../README.md";
+        let range = finder.find(input).unwrap();
+        assert_eq!("../README.md", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_home_path() {
+        let finder = Path::default();
+        let input = "config at ~/config/settings.json";
+        let range = finder.find(input).unwrap();
+        assert_eq!("~/config/settings.json", &input[range]);
+    }
+
+    // Line references
+    #[test]
+    fn find_should_include_line_number() {
+        let finder = Path::default();
+        let input = "error in ./src/main.rs:42 here";
+        let range = finder.find(input).unwrap();
+        assert_eq!("./src/main.rs:42", &input[range]);
+    }
+
+    #[test]
+    fn find_should_include_line_and_column() {
+        let finder = Path::default();
+        let input = "error at ./src/main.rs:42:10 found";
+        let range = finder.find(input).unwrap();
+        assert_eq!("./src/main.rs:42:10", &input[range]);
+    }
+
+    // Punctuation stripping
+    #[test]
+    fn find_should_strip_trailing_comma() {
+        let finder = Path::default();
+        let input = "files /etc/hosts, /etc/passwd";
+        let range = finder.find(input).unwrap();
+        assert_eq!("/etc/hosts", &input[range]);
+    }
+
+    #[test]
+    fn find_should_strip_trailing_period() {
+        let finder = Path::default();
+        let input = "see /etc/hosts.";
+        let range = finder.find(input).unwrap();
+        assert_eq!("/etc/hosts", &input[range]);
+    }
+
+    #[test]
+    fn find_should_strip_trailing_paren() {
+        let finder = Path::default();
+        let input = "(see /etc/hosts)";
+        let range = finder.find(input).unwrap();
+        assert_eq!("/etc/hosts", &input[range]);
+    }
+
+    #[test]
+    fn find_should_strip_trailing_colon() {
+        let finder = Path::default();
+        let input = "/etc/hosts: permission denied";
+        let range = finder.find(input).unwrap();
+        assert_eq!("/etc/hosts", &input[range]);
+    }
+
+    // Should NOT match
+    #[test]
+    fn find_should_not_match_uri_path() {
+        let finder = Path::default();
+        assert!(finder.find("https://example.com/path").is_none());
+    }
+
+    #[test]
+    fn find_should_not_match_bare_slash() {
+        let finder = Path::default();
+        assert!(finder.find("a / b").is_none());
+    }
+
+    #[test]
+    fn find_should_not_match_empty_input() {
+        let finder = Path::default();
+        assert!(finder.find("").is_none());
+    }
+
+    #[test]
+    fn find_should_not_match_no_paths() {
+        let finder = Path::default();
+        assert!(finder.find("just some text").is_none());
+    }
+
+    // Iterative extraction
+    #[test]
+    fn find_should_extract_multiple_paths_iteratively() {
+        let finder = Path::default();
+        let input = "copy /etc/hosts to /tmp/hosts";
+
+        let mut results = Vec::new();
+        let mut idx = 0;
+        while idx < input.len() {
+            if let Some(range) = finder.find(&input[idx..]) {
+                results.push(&input[idx + range.start..idx + range.end]);
+                idx += range.end;
+            } else {
+                break;
+            }
+        }
+
+        assert_eq!(vec!["/etc/hosts", "/tmp/hosts"], results);
+    }
+
+    // Path in quotes/brackets
+    #[test]
+    fn find_should_extract_path_in_quotes() {
+        let finder = Path::default();
+        let input = r#"open "/var/log/app.log" now"#;
+        let range = finder.find(input).unwrap();
+        assert_eq!("/var/log/app.log", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_path_in_brackets() {
+        let finder = Path::default();
+        let input = "see [/etc/config] for details";
+        let range = finder.find(input).unwrap();
+        assert_eq!("/etc/config", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_path_in_backticks() {
+        let finder = Path::default();
+        let input = "run `./script.sh` to start";
+        let range = finder.find(input).unwrap();
+        assert_eq!("./script.sh", &input[range]);
+    }
+
+    // Dotfiles
+    #[test]
+    fn find_should_handle_dotfiles() {
+        let finder = Path::default();
+        let input = "edit ~/.bashrc for settings";
+        let range = finder.find(input).unwrap();
+        assert_eq!("~/.bashrc", &input[range]);
+    }
+
+    #[test]
+    fn find_should_handle_hidden_dirs() {
+        let finder = Path::default();
+        let input = "see ~/.config/app/settings.toml";
+        let range = finder.find(input).unwrap();
+        assert_eq!("~/.config/app/settings.toml", &input[range]);
+    }
+
+    // Extension preservation
+    #[test]
+    fn find_should_preserve_file_extension() {
+        let finder = Path::default();
+        let input = "compile ./src/lib.rs now";
+        let range = finder.find(input).unwrap();
+        assert_eq!("./src/lib.rs", &input[range]);
+    }
+
+    #[test]
+    fn find_should_handle_multiple_extensions() {
+        let finder = Path::default();
+        let input = "extract /archive/data.tar.gz here";
+        let range = finder.find(input).unwrap();
+        assert_eq!("/archive/data.tar.gz", &input[range]);
+    }
+
+    #[test]
+    fn find_should_not_match_mid_word_slash() {
+        let finder = Path::default();
+        assert!(finder.find("and/or").is_none());
+    }
+
+    // Slash followed by space should not match
+    #[test]
+    fn find_should_not_match_slash_space() {
+        let finder = Path::default();
+        assert!(finder.find("/ foo").is_none());
+    }
+}

--- a/squeeze/path.rs
+++ b/squeeze/path.rs
@@ -6,8 +6,7 @@ pub struct Path {}
 
 impl Path {
     fn is_boundary(b: u8) -> bool {
-        b.is_ascii_whitespace()
-            || matches!(b, b'(' | b'[' | b'{' | b'<' | b'"' | b'\'' | b'`')
+        b.is_ascii_whitespace() || matches!(b, b'(' | b'[' | b'{' | b'<' | b'"' | b'\'' | b'`')
     }
 
     fn find_prefix(&self, input: &[u8], from: usize) -> Option<(usize, usize)> {

--- a/squeeze/phone.rs
+++ b/squeeze/phone.rs
@@ -1,0 +1,210 @@
+use super::Finder;
+use regex::Regex;
+use std::ops::Range;
+use std::sync::OnceLock;
+
+pub struct Phone {
+    regex: &'static Regex,
+}
+
+impl Default for Phone {
+    fn default() -> Self {
+        static RE: OnceLock<Regex> = OnceLock::new();
+        let regex = RE.get_or_init(|| {
+            Regex::new(concat!(
+                r"(?:",
+                // E.164 international: +CC with digits/separators
+                r"\+[1-9]\d{0,2}[\s.\-]?(?:\(?\d{1,4}\)?[\s.\-]?){1,4}\d",
+                r"|",
+                // North American: (XXX) XXX-XXXX
+                r"\(\d{3}\)[\s.\-]?\d{3}[\s.\-]?\d{4}",
+                r"|",
+                // North American: XXX-XXX-XXXX or XXX.XXX.XXXX (require separator)
+                r"\d{3}[\-\.]\d{3}[\-\.]\d{4}",
+                r")",
+            ))
+            .unwrap()
+        });
+        Phone { regex }
+    }
+}
+
+impl Phone {
+    fn count_digits(s: &str) -> usize {
+        s.bytes().filter(|b| b.is_ascii_digit()).count()
+    }
+}
+
+impl Finder for Phone {
+    fn id(&self) -> &'static str {
+        "phone"
+    }
+
+    fn find(&self, s: &str) -> Option<Range<usize>> {
+        let input = s.as_bytes();
+
+        for m in self.regex.find_iter(s) {
+            let start = m.start();
+            let end = m.end();
+            let matched = &s[start..end];
+
+            // Boundary before: not preceded by alphanumeric
+            if start > 0 && input[start - 1].is_ascii_alphanumeric() {
+                continue;
+            }
+
+            // Boundary after: not followed by digit
+            if end < input.len() && input[end].is_ascii_digit() {
+                continue;
+            }
+
+            let digit_count = Self::count_digits(matched);
+            if !(7..=15).contains(&digit_count) {
+                continue;
+            }
+
+            return Some(start..end);
+        }
+
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn id_should_return_phone() {
+        let finder = Phone::default();
+        assert_eq!("phone", finder.id());
+    }
+
+    // E.164 format
+    #[test]
+    fn find_should_extract_e164() {
+        let finder = Phone::default();
+        let input = "call +14155551234";
+        let range = finder.find(input).unwrap();
+        assert_eq!("+14155551234", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_e164_with_separators() {
+        let finder = Phone::default();
+        let input = "call +1-415-555-1234";
+        let range = finder.find(input).unwrap();
+        assert_eq!("+1-415-555-1234", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_e164_with_spaces() {
+        let finder = Phone::default();
+        let input = "call +1 415 555 1234";
+        let range = finder.find(input).unwrap();
+        assert_eq!("+1 415 555 1234", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_international_with_country_code() {
+        let finder = Phone::default();
+        let input = "+44 20 7946 0958";
+        let range = finder.find(input).unwrap();
+        assert_eq!("+44 20 7946 0958", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_e164_with_dots() {
+        let finder = Phone::default();
+        let input = "+1.415.555.1234";
+        let range = finder.find(input).unwrap();
+        assert_eq!("+1.415.555.1234", &input[range]);
+    }
+
+    // North American with parens
+    #[test]
+    fn find_should_extract_parens_format() {
+        let finder = Phone::default();
+        let input = "call (415) 555-1234";
+        let range = finder.find(input).unwrap();
+        assert_eq!("(415) 555-1234", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_parens_no_space() {
+        let finder = Phone::default();
+        let input = "(415)555-1234";
+        let range = finder.find(input).unwrap();
+        assert_eq!("(415)555-1234", &input[range]);
+    }
+
+    // North American with dashes
+    #[test]
+    fn find_should_extract_dashed_format() {
+        let finder = Phone::default();
+        let input = "call 415-555-1234";
+        let range = finder.find(input).unwrap();
+        assert_eq!("415-555-1234", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_dotted_format() {
+        let finder = Phone::default();
+        let input = "call 415.555.1234";
+        let range = finder.find(input).unwrap();
+        assert_eq!("415.555.1234", &input[range]);
+    }
+
+    // Rejection tests
+    #[test]
+    fn find_should_reject_plain_digits() {
+        let finder = Phone::default();
+        assert!(finder.find("1234567890").is_none());
+    }
+
+    #[test]
+    fn find_should_reject_short_number() {
+        let finder = Phone::default();
+        assert!(finder.find("+123").is_none());
+    }
+
+    #[test]
+    fn find_should_reject_preceded_by_alpha() {
+        let finder = Phone::default();
+        assert!(finder.find("x+14155551234").is_none());
+    }
+
+    #[test]
+    fn find_should_handle_empty_input() {
+        let finder = Phone::default();
+        assert!(finder.find("").is_none());
+    }
+
+    // Multiple
+    #[test]
+    fn find_should_extract_multiple_phones_iteratively() {
+        let finder = Phone::default();
+        let input = "+14155551234 and (212) 555-6789";
+
+        let mut results = Vec::new();
+        let mut idx = 0;
+        while idx < input.len() {
+            if let Some(range) = finder.find(&input[idx..]) {
+                results.push(&input[idx + range.start..idx + range.end]);
+                idx += range.end;
+            } else {
+                break;
+            }
+        }
+
+        assert_eq!(vec!["+14155551234", "(212) 555-6789"], results);
+    }
+
+    #[test]
+    fn find_should_extract_phone_in_text() {
+        let finder = Phone::default();
+        let input = "Call us at +1-800-555-0199 for support";
+        let range = finder.find(input).unwrap();
+        assert_eq!("+1-800-555-0199", &input[range]);
+    }
+}

--- a/squeeze/semver.rs
+++ b/squeeze/semver.rs
@@ -1,0 +1,307 @@
+use super::Finder;
+use std::ops::Range;
+
+#[derive(Default)]
+pub struct Semver {}
+
+impl Semver {
+    fn is_boundary_before(input: &[u8], pos: usize) -> bool {
+        if pos == 0 {
+            return true;
+        }
+        let b = input[pos - 1];
+        !b.is_ascii_alphanumeric() && b != b'.'
+    }
+
+    fn is_boundary_after(input: &[u8], pos: usize) -> bool {
+        if pos >= input.len() {
+            return true;
+        }
+        let b = input[pos];
+        !b.is_ascii_alphanumeric() && b != b'.' && b != b'-' && b != b'+'
+    }
+
+    fn parse_digits(input: &[u8], pos: usize) -> Option<usize> {
+        if pos >= input.len() || !input[pos].is_ascii_digit() {
+            return None;
+        }
+        let mut end = pos + 1;
+        while end < input.len() && input[end].is_ascii_digit() {
+            end += 1;
+        }
+        Some(end)
+    }
+
+    fn parse_prerelease_or_build(input: &[u8], pos: usize) -> usize {
+        let mut end = pos;
+        while end < input.len()
+            && (input[end].is_ascii_alphanumeric() || input[end] == b'-' || input[end] == b'.')
+        {
+            end += 1;
+        }
+        // Don't end on a dot
+        while end > pos && input[end - 1] == b'.' {
+            end -= 1;
+        }
+        end
+    }
+}
+
+impl Finder for Semver {
+    fn id(&self) -> &'static str {
+        "semver"
+    }
+
+    fn find(&self, s: &str) -> Option<Range<usize>> {
+        let input = s.as_bytes();
+        let mut idx = 0;
+
+        while idx < input.len() {
+            let start = idx;
+            let mut pos = idx;
+
+            // Optional v/V prefix
+            if pos < input.len() && (input[pos] == b'v' || input[pos] == b'V') {
+                if pos + 1 < input.len() && input[pos + 1].is_ascii_digit() {
+                    pos += 1;
+                } else {
+                    idx += 1;
+                    continue;
+                }
+            } else if pos < input.len() && input[pos].is_ascii_digit() {
+                // ok
+            } else {
+                idx += 1;
+                continue;
+            }
+
+            if !Self::is_boundary_before(input, start) {
+                idx += 1;
+                continue;
+            }
+
+            // MAJOR
+            let major_end = match Self::parse_digits(input, pos) {
+                Some(e) => e,
+                None => {
+                    idx += 1;
+                    continue;
+                }
+            };
+
+            // .MINOR
+            if major_end >= input.len() || input[major_end] != b'.' {
+                idx += 1;
+                continue;
+            }
+            let minor_end = match Self::parse_digits(input, major_end + 1) {
+                Some(e) => e,
+                None => {
+                    idx += 1;
+                    continue;
+                }
+            };
+
+            // .PATCH
+            if minor_end >= input.len() || input[minor_end] != b'.' {
+                idx += 1;
+                continue;
+            }
+            let patch_end = match Self::parse_digits(input, minor_end + 1) {
+                Some(e) => e,
+                None => {
+                    idx += 1;
+                    continue;
+                }
+            };
+
+            let mut end = patch_end;
+
+            // Optional -prerelease
+            if end < input.len() && input[end] == b'-' {
+                let pre_end = Self::parse_prerelease_or_build(input, end + 1);
+                if pre_end > end + 1 {
+                    end = pre_end;
+                }
+            }
+
+            // Optional +buildmeta
+            if end < input.len() && input[end] == b'+' {
+                let build_end = Self::parse_prerelease_or_build(input, end + 1);
+                if build_end > end + 1 {
+                    end = build_end;
+                }
+            }
+
+            if Self::is_boundary_after(input, end) {
+                return Some(start..end);
+            }
+
+            idx += 1;
+        }
+
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn id_should_return_semver() {
+        let finder = Semver::default();
+        assert_eq!("semver", finder.id());
+    }
+
+    #[test]
+    fn find_should_extract_simple_version() {
+        let finder = Semver::default();
+        let input = "version 1.0.0 released";
+        let range = finder.find(input).unwrap();
+        assert_eq!("1.0.0", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_version_with_v_prefix() {
+        let finder = Semver::default();
+        let input = "tag v2.3.1 created";
+        let range = finder.find(input).unwrap();
+        assert_eq!("v2.3.1", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_version_with_uppercase_v() {
+        let finder = Semver::default();
+        let input = "V1.0.0";
+        let range = finder.find(input).unwrap();
+        assert_eq!("V1.0.0", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_version_with_prerelease() {
+        let finder = Semver::default();
+        let input = "v1.0.0-rc.1 is out";
+        let range = finder.find(input).unwrap();
+        assert_eq!("v1.0.0-rc.1", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_version_with_build_meta() {
+        let finder = Semver::default();
+        let input = "1.0.0+build.42";
+        let range = finder.find(input).unwrap();
+        assert_eq!("1.0.0+build.42", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_version_with_prerelease_and_build() {
+        let finder = Semver::default();
+        let input = "v2.0.0-alpha.1+build.123";
+        let range = finder.find(input).unwrap();
+        assert_eq!("v2.0.0-alpha.1+build.123", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_version_with_large_numbers() {
+        let finder = Semver::default();
+        let input = "100.200.300";
+        let range = finder.find(input).unwrap();
+        assert_eq!("100.200.300", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_version_with_zeros() {
+        let finder = Semver::default();
+        let input = "0.0.0";
+        let range = finder.find(input).unwrap();
+        assert_eq!("0.0.0", &input[range]);
+    }
+
+    #[test]
+    fn find_should_reject_two_components() {
+        let finder = Semver::default();
+        assert!(finder.find("1.0 only").is_none());
+    }
+
+    #[test]
+    fn find_should_reject_four_components() {
+        let finder = Semver::default();
+        assert!(finder.find("1.0.0.0 too many").is_none());
+    }
+
+    #[test]
+    fn find_should_reject_preceded_by_alphanumeric() {
+        let finder = Semver::default();
+        assert!(finder.find("a1.0.0").is_none());
+    }
+
+    #[test]
+    fn find_should_reject_preceded_by_dot() {
+        let finder = Semver::default();
+        assert!(finder.find(".1.0.0").is_none());
+    }
+
+    #[test]
+    fn find_should_handle_empty_input() {
+        let finder = Semver::default();
+        assert!(finder.find("").is_none());
+    }
+
+    #[test]
+    fn find_should_extract_version_at_start() {
+        let finder = Semver::default();
+        let input = "1.2.3 is the version";
+        let range = finder.find(input).unwrap();
+        assert_eq!("1.2.3", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_version_at_end() {
+        let finder = Semver::default();
+        let input = "version is 1.2.3";
+        let range = finder.find(input).unwrap();
+        assert_eq!("1.2.3", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_multiple_versions_iteratively() {
+        let finder = Semver::default();
+        let input = "from 1.0.0 to 2.0.0";
+
+        let mut results = Vec::new();
+        let mut idx = 0;
+        while idx < input.len() {
+            if let Some(range) = finder.find(&input[idx..]) {
+                results.push(&input[idx + range.start..idx + range.end]);
+                idx += range.end;
+            } else {
+                break;
+            }
+        }
+
+        assert_eq!(vec!["1.0.0", "2.0.0"], results);
+    }
+
+    #[test]
+    fn find_should_extract_version_with_hyphen_prerelease() {
+        let finder = Semver::default();
+        let input = "1.0.0-beta-2";
+        let range = finder.find(input).unwrap();
+        assert_eq!("1.0.0-beta-2", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_version_in_parentheses() {
+        let finder = Semver::default();
+        let input = "(v1.2.3)";
+        let range = finder.find(input).unwrap();
+        assert_eq!("v1.2.3", &input[range]);
+    }
+
+    #[test]
+    fn find_should_not_match_ip_address() {
+        let finder = Semver::default();
+        assert!(finder.find("192.168.1.1").is_none());
+    }
+}

--- a/squeeze/tests/integration.rs
+++ b/squeeze/tests/integration.rs
@@ -1,15 +1,40 @@
-use squeeze::{codetag::Codetag, email::Email, mirror::Mirror, path::Path, uri::URI, Finder};
+use squeeze::{
+    codetag::Codetag, color::Color, email::Email, env::Env, hash::Hash, ip::Ip, json::Json,
+    mirror::Mirror, path::Path, phone::Phone, semver::Semver, uri::URI, uuid::Uuid, Finder,
+};
 
 #[test]
 fn finder_trait_id_should_be_unique() {
     let uri = URI::default();
     let mut codetag = Codetag::default();
     codetag.build_mnemonics_regex().unwrap();
+    let color = Color::default();
     let email = Email::default();
+    let env = Env::default();
+    let hash = Hash::default();
+    let ip = Ip::default();
+    let json = Json::default();
     let mirror = Mirror::default();
     let path = Path::default();
+    let phone = Phone::default();
+    let semver = Semver::default();
+    let uuid = Uuid::default();
 
-    let ids: Vec<&str> = vec![uri.id(), codetag.id(), email.id(), mirror.id(), path.id()];
+    let ids: Vec<&str> = vec![
+        uri.id(),
+        codetag.id(),
+        color.id(),
+        email.id(),
+        env.id(),
+        hash.id(),
+        ip.id(),
+        json.id(),
+        mirror.id(),
+        path.id(),
+        phone.id(),
+        semver.id(),
+        uuid.id(),
+    ];
     let mut unique_ids = ids.clone();
     unique_ids.sort();
     unique_ids.dedup();
@@ -210,10 +235,7 @@ fn email_finder_should_handle_real_world_formats() {
         ("user@example.com", "user@example.com"),
         ("first.last@company.co.uk", "first.last@company.co.uk"),
         ("user+tag@gmail.com", "user+tag@gmail.com"),
-        (
-            "From: Name <name@example.com>",
-            "name@example.com",
-        ),
+        ("From: Name <name@example.com>", "name@example.com"),
     ];
 
     for (input, expected) in emails {

--- a/squeeze/tests/integration.rs
+++ b/squeeze/tests/integration.rs
@@ -1,19 +1,24 @@
 use squeeze::{
-    codetag::Codetag, color::Color, email::Email, env::Env, hash::Hash, ip::Ip, json::Json,
-    mirror::Mirror, path::Path, phone::Phone, semver::Semver, uri::URI, uuid::Uuid, Finder,
+    cidr::Cidr, codetag::Codetag, color::Color, datetime::Datetime, email::Email, env::Env,
+    hash::Hash, ip::Ip, json::Json, jwt::Jwt, mac::Mac, mirror::Mirror, path::Path, phone::Phone,
+    semver::Semver, uri::URI, uuid::Uuid, Finder,
 };
 
 #[test]
 fn finder_trait_id_should_be_unique() {
+    let cidr = Cidr::default();
     let uri = URI::default();
     let mut codetag = Codetag::default();
     codetag.build_mnemonics_regex().unwrap();
     let color = Color::default();
+    let datetime = Datetime::default();
     let email = Email::default();
     let env = Env::default();
     let hash = Hash::default();
     let ip = Ip::default();
     let json = Json::default();
+    let jwt = Jwt::default();
+    let mac = Mac::default();
     let mirror = Mirror::default();
     let path = Path::default();
     let phone = Phone::default();
@@ -21,14 +26,18 @@ fn finder_trait_id_should_be_unique() {
     let uuid = Uuid::default();
 
     let ids: Vec<&str> = vec![
+        cidr.id(),
         uri.id(),
         codetag.id(),
         color.id(),
+        datetime.id(),
         email.id(),
         env.id(),
         hash.id(),
         ip.id(),
         json.id(),
+        jwt.id(),
+        mac.id(),
         mirror.id(),
         path.id(),
         phone.id(),

--- a/squeeze/tests/integration.rs
+++ b/squeeze/tests/integration.rs
@@ -1,13 +1,15 @@
-use squeeze::{codetag::Codetag, mirror::Mirror, uri::URI, Finder};
+use squeeze::{codetag::Codetag, email::Email, mirror::Mirror, path::Path, uri::URI, Finder};
 
 #[test]
 fn finder_trait_id_should_be_unique() {
     let uri = URI::default();
     let mut codetag = Codetag::default();
     codetag.build_mnemonics_regex().unwrap();
+    let email = Email::default();
     let mirror = Mirror::default();
+    let path = Path::default();
 
-    let ids: Vec<&str> = vec![uri.id(), codetag.id(), mirror.id()];
+    let ids: Vec<&str> = vec![uri.id(), codetag.id(), email.id(), mirror.id(), path.id()];
     let mut unique_ids = ids.clone();
     unique_ids.sort();
     unique_ids.dedup();
@@ -177,4 +179,94 @@ fn codetag_finder_hide_mnemonic_should_exclude_mnemonic_from_result() {
     let extracted = &input[result.unwrap()];
     assert!(!extracted.starts_with("TODO"));
     assert!(extracted.contains("implement this feature"));
+}
+
+#[test]
+fn email_finder_should_extract_emails_from_text() {
+    let finder = Email::default();
+    let text = "Contact alice@example.com or bob@test.org for help";
+
+    let mut results = Vec::new();
+    let mut idx = 0;
+    while idx < text.len() {
+        if let Some(range) = finder.find(&text[idx..]) {
+            results.push(&text[idx + range.start..idx + range.end]);
+            idx += range.end;
+        } else {
+            break;
+        }
+    }
+
+    assert_eq!(2, results.len());
+    assert_eq!("alice@example.com", results[0]);
+    assert_eq!("bob@test.org", results[1]);
+}
+
+#[test]
+fn email_finder_should_handle_real_world_formats() {
+    let finder = Email::default();
+
+    let emails = vec![
+        ("user@example.com", "user@example.com"),
+        ("first.last@company.co.uk", "first.last@company.co.uk"),
+        ("user+tag@gmail.com", "user+tag@gmail.com"),
+        (
+            "From: Name <name@example.com>",
+            "name@example.com",
+        ),
+    ];
+
+    for (input, expected) in emails {
+        let result = finder.find(input);
+        assert!(result.is_some(), "Should find email in: {}", input);
+        assert_eq!(expected, &input[result.unwrap()]);
+    }
+}
+
+#[test]
+fn path_finder_should_extract_paths_from_text() {
+    let finder = Path::default();
+    let text = "copy /etc/hosts to /tmp/backup";
+
+    let mut results = Vec::new();
+    let mut idx = 0;
+    while idx < text.len() {
+        if let Some(range) = finder.find(&text[idx..]) {
+            results.push(&text[idx + range.start..idx + range.end]);
+            idx += range.end;
+        } else {
+            break;
+        }
+    }
+
+    assert_eq!(2, results.len());
+    assert_eq!("/etc/hosts", results[0]);
+    assert_eq!("/tmp/backup", results[1]);
+}
+
+#[test]
+fn path_finder_should_handle_various_prefixes() {
+    let finder = Path::default();
+
+    let cases = vec![
+        ("/usr/local/bin/app", "/usr/local/bin/app"),
+        ("./src/main.rs", "./src/main.rs"),
+        ("../README.md", "../README.md"),
+        ("~/.bashrc", "~/.bashrc"),
+    ];
+
+    for (input, expected) in cases {
+        let result = finder.find(input);
+        assert!(result.is_some(), "Should find path in: {}", input);
+        assert_eq!(expected, &input[result.unwrap()]);
+    }
+}
+
+#[test]
+fn path_finder_should_handle_compiler_output() {
+    let finder = Path::default();
+    let input = "error at ./src/main.rs:42:10 something";
+    let result = finder.find(input);
+    assert!(result.is_some());
+    assert_eq!("./src/main.rs:42:10", &input[result.unwrap()]);
 }

--- a/squeeze/uuid.rs
+++ b/squeeze/uuid.rs
@@ -1,0 +1,200 @@
+use super::Finder;
+use std::ops::Range;
+
+#[derive(Default)]
+pub struct Uuid {}
+
+impl Uuid {
+    fn is_hex(b: u8) -> bool {
+        b.is_ascii_hexdigit()
+    }
+
+    fn check_pattern(input: &[u8], start: usize) -> bool {
+        if start + 36 > input.len() {
+            return false;
+        }
+        let groups = [8, 4, 4, 4, 12];
+        let mut pos = start;
+        for (i, &len) in groups.iter().enumerate() {
+            if i > 0 {
+                if input[pos] != b'-' {
+                    return false;
+                }
+                pos += 1;
+            }
+            for _ in 0..len {
+                if !Self::is_hex(input[pos]) {
+                    return false;
+                }
+                pos += 1;
+            }
+        }
+        true
+    }
+}
+
+impl Finder for Uuid {
+    fn id(&self) -> &'static str {
+        "uuid"
+    }
+
+    fn find(&self, s: &str) -> Option<Range<usize>> {
+        let input = s.as_bytes();
+        let mut idx = 0;
+
+        while idx + 36 <= input.len() {
+            if Self::is_hex(input[idx]) {
+                if idx > 0 && (Self::is_hex(input[idx - 1]) || input[idx - 1] == b'-') {
+                    idx += 1;
+                    continue;
+                }
+
+                if Self::check_pattern(input, idx) {
+                    let end = idx + 36;
+                    if end < input.len() && (Self::is_hex(input[end]) || input[end] == b'-') {
+                        idx += 1;
+                        continue;
+                    }
+                    return Some(idx..end);
+                }
+            }
+            idx += 1;
+        }
+
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn id_should_return_uuid() {
+        let finder = Uuid::default();
+        assert_eq!("uuid", finder.id());
+    }
+
+    #[test]
+    fn find_should_extract_uuid() {
+        let finder = Uuid::default();
+        let input = "id: 550e8400-e29b-41d4-a716-446655440000";
+        let range = finder.find(input).unwrap();
+        assert_eq!("550e8400-e29b-41d4-a716-446655440000", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_uuid_at_start() {
+        let finder = Uuid::default();
+        let input = "550e8400-e29b-41d4-a716-446655440000 is the id";
+        let range = finder.find(input).unwrap();
+        assert_eq!("550e8400-e29b-41d4-a716-446655440000", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_uppercase_uuid() {
+        let finder = Uuid::default();
+        let input = "550E8400-E29B-41D4-A716-446655440000";
+        let range = finder.find(input).unwrap();
+        assert_eq!("550E8400-E29B-41D4-A716-446655440000", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_mixed_case_uuid() {
+        let finder = Uuid::default();
+        let input = "550e8400-E29B-41d4-A716-446655440000";
+        let range = finder.find(input).unwrap();
+        assert_eq!("550e8400-E29B-41d4-A716-446655440000", &input[range]);
+    }
+
+    #[test]
+    fn find_should_reject_no_dashes() {
+        let finder = Uuid::default();
+        assert!(finder.find("550e8400e29b41d4a716446655440000").is_none());
+    }
+
+    #[test]
+    fn find_should_reject_wrong_dash_positions() {
+        let finder = Uuid::default();
+        assert!(finder
+            .find("550e840-0e29b-41d4-a716-446655440000")
+            .is_none());
+    }
+
+    #[test]
+    fn find_should_reject_too_short() {
+        let finder = Uuid::default();
+        assert!(finder.find("550e8400-e29b-41d4-a716").is_none());
+    }
+
+    #[test]
+    fn find_should_reject_non_hex() {
+        let finder = Uuid::default();
+        assert!(finder
+            .find("550e8400-e29b-41d4-a716-44665544000g")
+            .is_none());
+    }
+
+    #[test]
+    fn find_should_not_match_within_longer_hex() {
+        let finder = Uuid::default();
+        assert!(finder
+            .find("ff550e8400-e29b-41d4-a716-446655440000")
+            .is_none());
+    }
+
+    #[test]
+    fn find_should_not_match_with_trailing_hex() {
+        let finder = Uuid::default();
+        assert!(finder
+            .find("550e8400-e29b-41d4-a716-446655440000ff")
+            .is_none());
+    }
+
+    #[test]
+    fn find_should_extract_uuid_in_brackets() {
+        let finder = Uuid::default();
+        let input = "[550e8400-e29b-41d4-a716-446655440000]";
+        let range = finder.find(input).unwrap();
+        assert_eq!("550e8400-e29b-41d4-a716-446655440000", &input[range]);
+    }
+
+    #[test]
+    fn find_should_handle_empty_input() {
+        let finder = Uuid::default();
+        assert!(finder.find("").is_none());
+    }
+
+    #[test]
+    fn find_should_extract_multiple_uuids_iteratively() {
+        let finder = Uuid::default();
+        let input = "550e8400-e29b-41d4-a716-446655440000 and 6ba7b810-9dad-11d1-80b4-00c04fd430c8";
+
+        let mut results = Vec::new();
+        let mut idx = 0;
+        while idx < input.len() {
+            if let Some(range) = finder.find(&input[idx..]) {
+                results.push(&input[idx + range.start..idx + range.end]);
+                idx += range.end;
+            } else {
+                break;
+            }
+        }
+
+        assert_eq!(
+            vec![
+                "550e8400-e29b-41d4-a716-446655440000",
+                "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+            ],
+            results
+        );
+    }
+
+    #[test]
+    fn find_should_extract_nil_uuid() {
+        let finder = Uuid::default();
+        let input = "00000000-0000-0000-0000-000000000000";
+        let range = finder.find(input).unwrap();
+        assert_eq!("00000000-0000-0000-0000-000000000000", &input[range]);
+    }
+}


### PR DESCRIPTION
## Summary

- **Nightly version**: `squeeze --version` now shows `nightly-YYYYMMDD-SHA` when installed via the nightly Homebrew formula, using `SQUEEZE_VERSION` env var at compile time with fallback to `CARGO_PKG_VERSION`.

- **14 new finders** bringing the total to 17 (up from codetag, uri, and mirror):

| Finder | Flag | Examples |
|--------|------|----------|
| CIDR | `--cidr` | `192.168.1.0/24`, `2001:db8::/32` |
| Colors | `--color` | `#ff0000`, `rgb(255, 0, 0)` |
| Datetimes | `--datetime` | `2024-01-15`, `2024-01-15T10:30:00Z` |
| Emails | `--email` | `user@example.com` |
| Env vars | `--env` | `$HOME`, `${PATH}` |
| Hashes | `--hash`, `--md5`, `--sha256` | `5d41402abc4b2a76b9719d911017c592` |
| IPs | `--ip`, `--ipv4`, `--ipv6` | `192.168.1.1`, `::1` |
| JSON | `--json` | `{"key": "value"}`, `[1, 2, 3]` |
| JWTs | `--jwt` | `eyJhbGciOiJIUzI1NiJ9...` |
| MACs | `--mac` | `00:1A:2B:3C:4D:5E` |
| Paths | `--path` | `/etc/hosts`, `./src/main.rs:42:10` |
| Phones | `--phone` | `+14155551234`, `(415) 555-1234` |
| Semver | `--semver` | `1.0.0`, `v2.3.1-rc.1` |
| UUIDs | `--uuid` | `550e8400-e29b-41d4-a716-446655440000` |

- **README**: Replaced the two-item bullet list with a full table of all finders, updated the Getting Started section with more examples.

## Test plan

- [x] All 443 tests pass (`cargo test`)
- [x] Zero clippy warnings (`cargo clippy`)
- [x] `SQUEEZE_VERSION=nightly-test cargo run -- --version` shows `nightly-test`
- [x] Each new finder works end-to-end via CLI flags
- [ ] Verify nightly CI produces correct version after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)