### PR TITLE
Add consolidated scanner with dispatch table, fuzz testing, and Rust 2024 edition

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,0 @@
-[build]
-rustflags = ["-C", "target-cpu=native"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,15 @@ jobs:
       - name: cargo build
         run: cargo build
 
+      - name: Remove proptest for MSRV
+        run: |
+          sed -i '/^proptest/d' squeeze/Cargo.toml
+          rm -f squeeze/tests/fuzz.rs
+
       - name: cargo test
-        run: cargo test
+        run: cargo test -- --test-threads=1
+        env:
+          RUST_BACKTRACE: 1
 
   # Cross-platform testing
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@1.85
+      - uses: dtolnay/rust-toolchain@1.95
         # MSRV defined in squeeze/Cargo.toml
 
       - uses: Swatinem/rust-cache@v2
@@ -46,15 +46,8 @@ jobs:
       - name: cargo build
         run: cargo build
 
-      - name: Remove proptest for MSRV
-        run: |
-          sed -i '/^proptest/d' squeeze/Cargo.toml
-          rm -f squeeze/tests/fuzz.rs
-
       - name: cargo test
-        run: cargo test -- --test-threads=1
-        env:
-          RUST_BACKTRACE: 1
+        run: cargo test --all-targets
 
   # Cross-platform testing
   test:

--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,8 @@ target/
 .DS_Store
 Thumbs.db
 
+# Proptest
+proptest-regressions/
+
 # Cargo lock for libraries (keep for binaries)
 # Cargo.lock

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,9 +69,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "assert_cmd"
-version = "2.2.2"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aa3a22042e45de04255c7bf3626e239f450200fd0493c1e382263544b20aea6"
+checksum = "39bae1d3fa576f7c6519514180a72559268dd7d1fe104070956cb687bc6673bd"
 dependencies = [
  "anstyle",
  "bstr",
@@ -428,9 +428,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "open"
-version = "5.3.5"
+version = "5.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fbaa89d2ddc8473c78a3adf69eea8cffa28c483b8e02a971ef31527cd0fc92c"
+checksum = "9f3bab717c29a857abf75fcef718d441ec7cb2725f937343c734740a985d37fd"
 dependencies = [
  "is-wsl",
  "libc",
@@ -747,9 +747,9 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "1.0.3"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "squeeze"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,9 +69,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "assert_cmd"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39bae1d3fa576f7c6519514180a72559268dd7d1fe104070956cb687bc6673bd"
+checksum = "2aa3a22042e45de04255c7bf3626e239f450200fd0493c1e382263544b20aea6"
 dependencies = [
  "anstyle",
  "bstr",
@@ -428,9 +428,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "open"
-version = "5.3.4"
+version = "5.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3bab717c29a857abf75fcef718d441ec7cb2725f937343c734740a985d37fd"
+checksum = "2fbaa89d2ddc8473c78a3adf69eea8cffa28c483b8e02a971ef31527cd0fc92c"
 dependencies = [
  "is-wsl",
  "libc",
@@ -747,16 +747,15 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "squeeze"
 version = "0.1.0"
 dependencies = [
  "glob",
- "memchr",
  "phf",
  "proptest",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -756,6 +756,7 @@ name = "squeeze"
 version = "0.1.0"
 dependencies = [
  "glob",
+ "memchr",
  "phf",
  "proptest",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,9 +69,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "assert_cmd"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39bae1d3fa576f7c6519514180a72559268dd7d1fe104070956cb687bc6673bd"
+checksum = "2aa3a22042e45de04255c7bf3626e239f450200fd0493c1e382263544b20aea6"
 dependencies = [
  "anstyle",
  "bstr",
@@ -428,9 +428,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "open"
-version = "5.3.4"
+version = "5.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3bab717c29a857abf75fcef718d441ec7cb2725f937343c734740a985d37fd"
+checksum = "2fbaa89d2ddc8473c78a3adf69eea8cffa28c483b8e02a971ef31527cd0fc92c"
 dependencies = [
  "is-wsl",
  "libc",
@@ -747,9 +747,9 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "squeeze"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "assert_cmd"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -83,6 +89,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -92,6 +119,12 @@ dependencies = [
  "regex-automata",
  "serde",
 ]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
@@ -169,6 +202,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,16 +233,86 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "is-docker"
@@ -221,6 +340,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
 name = "jiff"
 version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -245,10 +370,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
@@ -365,6 +502,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "predicates"
 version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -395,6 +541,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -404,12 +560,87 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -442,6 +673,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -471,6 +733,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -482,6 +757,7 @@ version = "0.1.0"
 dependencies = [
  "glob",
  "phf",
+ "proptest",
  "regex",
  "regex-syntax",
 ]
@@ -517,16 +793,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "utf8parse"
@@ -544,6 +845,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -557,3 +910,123 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,5 @@ opt-level = 0
 codegen-units = 1
 lto = "fat"
 opt-level = 3
+panic = "abort"
+strip = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [
   "squeeze",
   "squeeze-cli",
 ]
-resolver = "2"
+resolver = "3"
 
 [profile.dev]
 opt-level = 0

--- a/squeeze-cli/Cargo.toml
+++ b/squeeze-cli/Cargo.toml
@@ -2,8 +2,8 @@
 name = "squeeze-cli"
 version = "0.1.0"
 authors = ["Aymeric Beaumet <hi@aymericbeaumet.com>"]
-edition = "2021"
-rust-version = "1.85"
+edition = "2024"
+rust-version = "1.95"
 license = "MIT"
 description = "CLI tool to extract rich information from any text"
 repository = "https://github.com/aymericbeaumet/squeeze"
@@ -16,7 +16,7 @@ name = "squeeze"
 path = "main.rs"
 
 [dependencies]
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.6", features = ["derive"] }
 log = "0.4"
 env_logger = "0.11"
 open = "5"

--- a/squeeze-cli/main.rs
+++ b/squeeze-cli/main.rs
@@ -1,11 +1,11 @@
 use clap::Parser;
 use squeeze::{
-    cidr::Cidr, codetag::Codetag, color::Color, datetime::Datetime, email::Email, env::Env,
-    hash::Hash, ip::Ip, json::Json, jwt::Jwt, mac::Mac, mirror::Mirror, path::Path, phone::Phone,
-    semver::Semver, uri::URI, uuid::Uuid, Finder,
+    cidr::Cidr, codetag::Codetag, color::Color, datetime::Datetime, email::Email, emoji::Emoji,
+    env::Env, hash::Hash, ip::Ip, json::Json, jwt::Jwt, mac::Mac, mirror::Mirror, path::Path,
+    phone::Phone, scanner::Scanner, semver::Semver, uri::URI, uuid::Uuid, Finder,
 };
 use std::convert::{TryFrom, TryInto};
-use std::io::{self, BufRead};
+use std::io::{self, BufRead, BufWriter, Write};
 use std::process::ExitCode;
 
 const VERSION: &str = match option_env!("SQUEEZE_VERSION") {
@@ -55,6 +55,10 @@ struct Opts {
     // email
     #[arg(long = "email", help = "search for email addresses")]
     email: bool,
+
+    // emoji
+    #[arg(long = "emoji", help = "search for emojis")]
+    emoji: bool,
 
     // env
     #[arg(long = "env", help = "search for environment variables")]
@@ -176,6 +180,18 @@ impl TryFrom<&Opts> for Email {
         }
 
         Ok(Email::default())
+    }
+}
+
+impl TryFrom<&Opts> for Emoji {
+    type Error = ();
+
+    fn try_from(opts: &Opts) -> Result<Self, Self::Error> {
+        if !opts.emoji {
+            return Err(());
+        }
+
+        Ok(Emoji::default())
     }
 }
 
@@ -400,50 +416,71 @@ fn main() -> ExitCode {
     env_logger::init();
 
     let opts = Opts::parse();
-    let cidr = TryInto::<Cidr>::try_into(&opts);
-    let codetag = TryInto::<Codetag>::try_into(&opts);
-    let color = TryInto::<Color>::try_into(&opts);
-    let datetime = TryInto::<Datetime>::try_into(&opts);
-    let email = TryInto::<Email>::try_into(&opts);
-    let env = TryInto::<Env>::try_into(&opts);
-    let hash = TryInto::<Hash>::try_into(&opts);
-    let ip = TryInto::<Ip>::try_into(&opts);
-    let json = TryInto::<Json>::try_into(&opts);
-    let jwt = TryInto::<Jwt>::try_into(&opts);
-    let mac = TryInto::<Mac>::try_into(&opts);
-    let mirror = TryInto::<Mirror>::try_into(&opts);
-    let path = TryInto::<Path>::try_into(&opts);
-    let phone = TryInto::<Phone>::try_into(&opts);
-    let semver = TryInto::<Semver>::try_into(&opts);
-    let uri = TryInto::<URI>::try_into(&opts);
-    let uuid = TryInto::<Uuid>::try_into(&opts);
 
-    let finders: Vec<_> = [
-        cidr.as_ref().map(|f| f as &dyn Finder),
-        codetag.as_ref().map(|f| f as &dyn Finder),
-        color.as_ref().map(|f| f as &dyn Finder),
-        datetime.as_ref().map(|f| f as &dyn Finder),
-        email.as_ref().map(|f| f as &dyn Finder),
-        env.as_ref().map(|f| f as &dyn Finder),
-        hash.as_ref().map(|f| f as &dyn Finder),
-        ip.as_ref().map(|f| f as &dyn Finder),
-        json.as_ref().map(|f| f as &dyn Finder),
-        jwt.as_ref().map(|f| f as &dyn Finder),
-        mac.as_ref().map(|f| f as &dyn Finder),
-        mirror.as_ref().map(|f| f as &dyn Finder),
-        path.as_ref().map(|f| f as &dyn Finder),
-        phone.as_ref().map(|f| f as &dyn Finder),
-        semver.as_ref().map(|f| f as &dyn Finder),
-        uri.as_ref().map(|f| f as &dyn Finder),
-        uuid.as_ref().map(|f| f as &dyn Finder),
-    ]
-    .into_iter()
-    .filter_map(|finder| finder.ok())
-    .collect();
+    let mut finders: Vec<Box<dyn Finder>> = Vec::new();
+    if let Ok(f) = TryInto::<Cidr>::try_into(&opts) {
+        finders.push(Box::new(f));
+    }
+    if let Ok(f) = TryInto::<Codetag>::try_into(&opts) {
+        finders.push(Box::new(f));
+    }
+    if let Ok(f) = TryInto::<Color>::try_into(&opts) {
+        finders.push(Box::new(f));
+    }
+    if let Ok(f) = TryInto::<Datetime>::try_into(&opts) {
+        finders.push(Box::new(f));
+    }
+    if let Ok(f) = TryInto::<Email>::try_into(&opts) {
+        finders.push(Box::new(f));
+    }
+    if let Ok(f) = TryInto::<Emoji>::try_into(&opts) {
+        finders.push(Box::new(f));
+    }
+    if let Ok(f) = TryInto::<Env>::try_into(&opts) {
+        finders.push(Box::new(f));
+    }
+    if let Ok(f) = TryInto::<Hash>::try_into(&opts) {
+        finders.push(Box::new(f));
+    }
+    if let Ok(f) = TryInto::<Ip>::try_into(&opts) {
+        finders.push(Box::new(f));
+    }
+    if let Ok(f) = TryInto::<Json>::try_into(&opts) {
+        finders.push(Box::new(f));
+    }
+    if let Ok(f) = TryInto::<Jwt>::try_into(&opts) {
+        finders.push(Box::new(f));
+    }
+    if let Ok(f) = TryInto::<Mac>::try_into(&opts) {
+        finders.push(Box::new(f));
+    }
+    if let Ok(f) = TryInto::<Mirror>::try_into(&opts) {
+        finders.push(Box::new(f));
+    }
+    if let Ok(f) = TryInto::<Path>::try_into(&opts) {
+        finders.push(Box::new(f));
+    }
+    if let Ok(f) = TryInto::<Phone>::try_into(&opts) {
+        finders.push(Box::new(f));
+    }
+    if let Ok(f) = TryInto::<Semver>::try_into(&opts) {
+        finders.push(Box::new(f));
+    }
+    if let Ok(f) = TryInto::<URI>::try_into(&opts) {
+        finders.push(Box::new(f));
+    }
+    if let Ok(f) = TryInto::<Uuid>::try_into(&opts) {
+        finders.push(Box::new(f));
+    }
 
     if finders.is_empty() {
         return ExitCode::SUCCESS;
     }
+
+    let scanner = Scanner::new(finders);
+
+    let stdout = io::stdout().lock();
+    let mut out = BufWriter::new(stdout);
 
     for line in io::stdin().lock().lines() {
         let line = match line {
@@ -454,29 +491,29 @@ fn main() -> ExitCode {
             }
         };
 
-        for finder in &finders {
-            log::debug!("[{}] line \"{}\"", finder.id(), line);
-            let mut idx = 0;
-            while idx < line.len() {
-                let segment = &line[idx..];
-                log::debug!("[{}] searching in \"{}\"", finder.id(), segment);
-                if let Some(range) = finder.find(segment) {
-                    log::debug!("[{}] found at [{};{}[", finder.id(), range.start, range.end);
-                    idx += range.end;
-                    let found = &segment[range].trim();
-                    if !found.is_empty() {
-                        println!("{}", found);
-                        if opts.open {
-                            if let Err(e) = open_url(found) {
-                                eprintln!("failed to open '{}': {}", found, e);
-                            }
-                        }
-                        if opts.first {
-                            return ExitCode::SUCCESS;
+        if opts.first {
+            if let Some(m) = scanner.scan_line_first(&line) {
+                let found = &line[m.range];
+                if !found.is_empty() {
+                    let _ = writeln!(out, "{}", found);
+                    if opts.open {
+                        if let Err(e) = open_url(found) {
+                            eprintln!("failed to open '{}': {}", found, e);
                         }
                     }
-                } else {
-                    break;
+                    return ExitCode::SUCCESS;
+                }
+            }
+        } else {
+            for m in scanner.scan_line(&line) {
+                let found = &line[m.range];
+                if !found.is_empty() {
+                    let _ = writeln!(out, "{}", found);
+                    if opts.open {
+                        if let Err(e) = open_url(found) {
+                            eprintln!("failed to open '{}': {}", found, e);
+                        }
+                    }
                 }
             }
         }

--- a/squeeze-cli/main.rs
+++ b/squeeze-cli/main.rs
@@ -481,19 +481,24 @@ fn main() -> ExitCode {
 
     let stdout = io::stdout().lock();
     let mut out = BufWriter::new(stdout);
+    let mut stdin = io::stdin().lock();
+    let mut line = String::new();
 
-    for line in io::stdin().lock().lines() {
-        let line = match line {
-            Ok(line) => line,
+    loop {
+        line.clear();
+        match stdin.read_line(&mut line) {
+            Ok(0) => break,
+            Ok(_) => {}
             Err(e) => {
                 log::error!("failed to read line: {}", e);
                 continue;
             }
-        };
+        }
+        let trimmed = line.trim_end_matches('\n').trim_end_matches('\r');
 
         if opts.first {
-            if let Some(m) = scanner.scan_line_first(&line) {
-                let found = &line[m.range];
+            if let Some(m) = scanner.scan_line_first(trimmed) {
+                let found = &trimmed[m.range];
                 if !found.is_empty() {
                     let _ = writeln!(out, "{}", found);
                     if opts.open {
@@ -505,8 +510,8 @@ fn main() -> ExitCode {
                 }
             }
         } else {
-            for m in scanner.scan_line(&line) {
-                let found = &line[m.range];
+            for m in scanner.scan_line(trimmed) {
+                let found = &trimmed[m.range];
                 if !found.is_empty() {
                     let _ = writeln!(out, "{}", found);
                     if opts.open {

--- a/squeeze-cli/main.rs
+++ b/squeeze-cli/main.rs
@@ -483,6 +483,7 @@ fn main() -> ExitCode {
     let mut out = BufWriter::new(stdout);
     let mut stdin = io::stdin().lock();
     let mut line = String::new();
+    let mut matches_buf = Vec::new();
 
     loop {
         line.clear();
@@ -510,8 +511,9 @@ fn main() -> ExitCode {
                 }
             }
         } else {
-            for m in scanner.scan_line(trimmed) {
-                let found = &trimmed[m.range];
+            scanner.scan_line_into(trimmed, &mut matches_buf);
+            for m in &matches_buf {
+                let found = &trimmed[m.range.clone()];
                 if !found.is_empty() {
                     let _ = writeln!(out, "{}", found);
                     if opts.open {

--- a/squeeze-cli/main.rs
+++ b/squeeze-cli/main.rs
@@ -1,8 +1,8 @@
 use clap::Parser;
 use squeeze::{
-    cidr::Cidr, codetag::Codetag, color::Color, datetime::Datetime, email::Email, emoji::Emoji,
-    env::Env, hash::Hash, ip::Ip, json::Json, jwt::Jwt, mac::Mac, mirror::Mirror, path::Path,
-    phone::Phone, scanner::Scanner, semver::Semver, uri::URI, uuid::Uuid, Finder,
+    Finder, cidr::Cidr, codetag::Codetag, color::Color, datetime::Datetime, email::Email,
+    emoji::Emoji, env::Env, hash::Hash, ip::Ip, json::Json, jwt::Jwt, mac::Mac, mirror::Mirror,
+    path::Path, phone::Phone, scanner::Scanner, semver::Semver, uri::URI, uuid::Uuid,
 };
 use std::convert::{TryFrom, TryInto};
 use std::io::{self, BufRead, BufWriter, Write};
@@ -502,10 +502,10 @@ fn main() -> ExitCode {
                 let found = &trimmed[m.range];
                 if !found.is_empty() {
                     let _ = writeln!(out, "{}", found);
-                    if opts.open {
-                        if let Err(e) = open_url(found) {
-                            eprintln!("failed to open '{}': {}", found, e);
-                        }
+                    if opts.open
+                        && let Err(e) = open_url(found)
+                    {
+                        eprintln!("failed to open '{}': {}", found, e);
                     }
                     return ExitCode::SUCCESS;
                 }
@@ -516,10 +516,10 @@ fn main() -> ExitCode {
                 let found = &trimmed[m.range.clone()];
                 if !found.is_empty() {
                     let _ = writeln!(out, "{}", found);
-                    if opts.open {
-                        if let Err(e) = open_url(found) {
-                            eprintln!("failed to open '{}': {}", found, e);
-                        }
+                    if opts.open
+                        && let Err(e) = open_url(found)
+                    {
+                        eprintln!("failed to open '{}': {}", found, e);
                     }
                 }
             }

--- a/squeeze/Cargo.toml
+++ b/squeeze/Cargo.toml
@@ -22,3 +22,4 @@ regex-syntax = "0.8"
 
 [dev-dependencies]
 glob = "0.3"
+proptest = "1"

--- a/squeeze/Cargo.toml
+++ b/squeeze/Cargo.toml
@@ -16,7 +16,6 @@ name = "squeeze"
 path = "lib.rs"
 
 [dependencies]
-memchr = "2"
 phf = { version = "0.13", features = ["macros"] }
 regex = "1.11"
 regex-syntax = "0.8"

--- a/squeeze/Cargo.toml
+++ b/squeeze/Cargo.toml
@@ -2,8 +2,8 @@
 name = "squeeze"
 version = "0.1.0"
 authors = ["Aymeric Beaumet <hi@aymericbeaumet.com>"]
-edition = "2021"
-rust-version = "1.85"
+edition = "2024"
+rust-version = "1.95"
 license = "MIT"
 description = "Extract rich information from any text (URIs, codetags, etc.)"
 repository = "https://github.com/aymericbeaumet/squeeze"
@@ -17,7 +17,7 @@ path = "lib.rs"
 
 [dependencies]
 phf = { version = "0.13", features = ["macros"] }
-regex = "1.11"
+regex = "1.12"
 regex-syntax = "0.8"
 
 [dev-dependencies]

--- a/squeeze/Cargo.toml
+++ b/squeeze/Cargo.toml
@@ -16,6 +16,7 @@ name = "squeeze"
 path = "lib.rs"
 
 [dependencies]
+memchr = "2"
 phf = { version = "0.13", features = ["macros"] }
 regex = "1.11"
 regex-syntax = "0.8"

--- a/squeeze/cidr.rs
+++ b/squeeze/cidr.rs
@@ -172,7 +172,7 @@ impl Finder for Cidr {
     }
 
     fn could_start_at(&self, byte: u8) -> bool {
-        byte.is_ascii_digit() || byte.is_ascii_hexdigit() || byte == b':' || byte == b'['
+        byte.is_ascii_hexdigit() || byte == b':' || byte == b'['
     }
 
     fn try_at(&self, input: &[u8], pos: usize) -> Option<Range<usize>> {
@@ -448,5 +448,45 @@ mod tests {
         let input = "::/0";
         let range = finder.find(input).unwrap();
         assert_eq!("::/0", &input[range]);
+    }
+
+    // --- Regression: could_start_at without redundant digit check ---
+
+    #[test]
+    fn could_start_at_digit() {
+        let finder = Cidr::default();
+        for b in b'0'..=b'9' {
+            assert!(
+                finder.could_start_at(b),
+                "should start at digit {}",
+                b as char
+            );
+        }
+    }
+
+    #[test]
+    fn could_start_at_hex_alpha() {
+        let finder = Cidr::default();
+        for b in b'a'..=b'f' {
+            assert!(finder.could_start_at(b), "should start at {}", b as char);
+        }
+        for b in b'A'..=b'F' {
+            assert!(finder.could_start_at(b), "should start at {}", b as char);
+        }
+    }
+
+    #[test]
+    fn could_start_at_colon_bracket() {
+        let finder = Cidr::default();
+        assert!(finder.could_start_at(b':'));
+        assert!(finder.could_start_at(b'['));
+    }
+
+    #[test]
+    fn could_not_start_at_non_hex() {
+        let finder = Cidr::default();
+        assert!(!finder.could_start_at(b'g'));
+        assert!(!finder.could_start_at(b' '));
+        assert!(!finder.could_start_at(b'/'));
     }
 }

--- a/squeeze/cidr.rs
+++ b/squeeze/cidr.rs
@@ -40,8 +40,10 @@ impl Cidr {
                 return None;
             }
 
-            let octet_str = std::str::from_utf8(&input[octet_start..pos]).ok()?;
-            let value: u16 = octet_str.parse().ok()?;
+            let mut value: u16 = 0;
+            for i in octet_start..pos {
+                value = value * 10 + (input[i] - b'0') as u16;
+            }
             if value > 255 {
                 return None;
             }
@@ -67,8 +69,10 @@ impl Cidr {
             return None;
         }
 
-        let prefix_str = std::str::from_utf8(&input[prefix_start..pos]).ok()?;
-        let prefix: u8 = prefix_str.parse().ok()?;
+        let mut prefix: u8 = 0;
+        for i in prefix_start..pos {
+            prefix = prefix * 10 + (input[i] - b'0') as u8;
+        }
         if prefix > 32 {
             return None;
         }
@@ -88,7 +92,7 @@ impl Cidr {
             let close = input[idx..].iter().position(|&b| b == b']')?;
             let close_pos = idx + close;
             let inner = &input[idx + 1..close_pos];
-            if !Self::is_valid_ipv6(inner) {
+            if !crate::ipv6::is_valid_ipv6(inner) {
                 return None;
             }
             (idx, close_pos + 1)
@@ -116,7 +120,7 @@ impl Cidr {
             if !candidate.contains(&b':') {
                 return None;
             }
-            if !Self::is_valid_ipv6(candidate) {
+            if !crate::ipv6::is_valid_ipv6(candidate) {
                 return None;
             }
             (start, end)
@@ -141,8 +145,10 @@ impl Cidr {
             return None;
         }
 
-        let prefix_str = std::str::from_utf8(&input[prefix_start..pos]).ok()?;
-        let prefix: u16 = prefix_str.parse().ok()?;
+        let mut prefix: u16 = 0;
+        for i in prefix_start..pos {
+            prefix = prefix * 10 + (input[i] - b'0') as u16;
+        }
         if prefix > 128 {
             return None;
         }
@@ -155,58 +161,33 @@ impl Cidr {
         Some(ip_start..pos)
     }
 
-    fn is_valid_ipv6(bytes: &[u8]) -> bool {
-        let s = match std::str::from_utf8(bytes) {
-            Ok(s) => s,
-            Err(_) => return false,
-        };
-
-        if s == "::" {
-            return true;
-        }
-
-        let has_double_colon = s.contains("::");
-
-        if has_double_colon {
-            let parts: Vec<&str> = s.splitn(2, "::").collect();
-            if parts.len() != 2 {
-                return false;
-            }
-
-            let left: Vec<&str> = if parts[0].is_empty() {
-                vec![]
-            } else {
-                parts[0].split(':').collect()
-            };
-
-            let right: Vec<&str> = if parts[1].is_empty() {
-                vec![]
-            } else {
-                parts[1].split(':').collect()
-            };
-
-            let total = left.len() + right.len();
-            if total >= 8 {
-                return false;
-            }
-
-            left.iter()
-                .chain(right.iter())
-                .all(|g| Self::is_valid_hex_group(g))
-        } else {
-            let groups: Vec<&str> = s.split(':').collect();
-            groups.len() == 8 && groups.iter().all(|g| Self::is_valid_hex_group(g))
-        }
-    }
-
-    fn is_valid_hex_group(g: &str) -> bool {
-        !g.is_empty() && g.len() <= 4 && g.bytes().all(|b| b.is_ascii_hexdigit())
-    }
 }
 
 impl Finder for Cidr {
     fn id(&self) -> &'static str {
         "cidr"
+    }
+
+    fn dispatchable(&self) -> bool {
+        true
+    }
+
+    fn could_start_at(&self, byte: u8) -> bool {
+        byte.is_ascii_digit() || byte.is_ascii_hexdigit() || byte == b':' || byte == b'['
+    }
+
+    fn try_at(&self, input: &[u8], pos: usize) -> Option<Range<usize>> {
+        if input[pos].is_ascii_digit() {
+            if let Some(range) = Self::try_ipv4_cidr(input, pos) {
+                return Some(range);
+            }
+        }
+        if input[pos] == b'[' || input[pos].is_ascii_hexdigit() || input[pos] == b':' {
+            if let Some(range) = Self::try_ipv6_cidr(input, pos) {
+                return Some(range);
+            }
+        }
+        None
     }
 
     fn find(&self, s: &str) -> Option<Range<usize>> {
@@ -397,5 +378,76 @@ mod tests {
         let input = "subnet is 172.16.0.0/12";
         let range = finder.find(input).unwrap();
         assert_eq!("172.16.0.0/12", &input[range]);
+    }
+
+    #[test]
+    fn try_at_ipv4_cidr() {
+        let finder = Cidr::default();
+        let input = b"192.168.1.0/24 rest";
+        assert_eq!(finder.try_at(input, 0), Some(0..14));
+    }
+
+    #[test]
+    fn try_at_ipv6_cidr() {
+        let finder = Cidr::default();
+        let input = b"2001:db8::/32 rest";
+        assert_eq!(finder.try_at(input, 0), Some(0..13));
+    }
+
+    #[test]
+    fn try_at_no_prefix() {
+        let finder = Cidr::default();
+        let input = b"192.168.1.0 no prefix";
+        assert!(finder.try_at(input, 0).is_none());
+    }
+
+    #[test]
+    fn try_at_non_digit() {
+        let finder = Cidr::default();
+        assert!(finder.try_at(b"abc", 0).is_none());
+    }
+
+    #[test]
+    fn try_at_single_digit() {
+        let finder = Cidr::default();
+        assert!(finder.try_at(b"1", 0).is_none());
+    }
+
+    #[test]
+    fn find_prefix_zero() {
+        let finder = Cidr::default();
+        let input = "0.0.0.0/0";
+        let range = finder.find(input).unwrap();
+        assert_eq!("0.0.0.0/0", &input[range]);
+    }
+
+    #[test]
+    fn find_prefix_32() {
+        let finder = Cidr::default();
+        let input = "10.0.0.1/32";
+        let range = finder.find(input).unwrap();
+        assert_eq!("10.0.0.1/32", &input[range]);
+    }
+
+    #[test]
+    fn find_rejects_prefix_with_leading_zero() {
+        let finder = Cidr::default();
+        assert!(finder.find("10.0.0.0/08").is_none());
+    }
+
+    #[test]
+    fn find_ipv6_prefix_128() {
+        let finder = Cidr::default();
+        let input = "::1/128";
+        let range = finder.find(input).unwrap();
+        assert_eq!("::1/128", &input[range]);
+    }
+
+    #[test]
+    fn find_ipv6_prefix_zero() {
+        let finder = Cidr::default();
+        let input = "::/0";
+        let range = finder.find(input).unwrap();
+        assert_eq!("::/0", &input[range]);
     }
 }

--- a/squeeze/cidr.rs
+++ b/squeeze/cidr.rs
@@ -176,15 +176,15 @@ impl Finder for Cidr {
     }
 
     fn try_at(&self, input: &[u8], pos: usize) -> Option<Range<usize>> {
-        if input[pos].is_ascii_digit() {
-            if let Some(range) = Self::try_ipv4_cidr(input, pos) {
-                return Some(range);
-            }
+        if input[pos].is_ascii_digit()
+            && let Some(range) = Self::try_ipv4_cidr(input, pos)
+        {
+            return Some(range);
         }
-        if input[pos] == b'[' || input[pos].is_ascii_hexdigit() || input[pos] == b':' {
-            if let Some(range) = Self::try_ipv6_cidr(input, pos) {
-                return Some(range);
-            }
+        if (input[pos] == b'[' || input[pos].is_ascii_hexdigit() || input[pos] == b':')
+            && let Some(range) = Self::try_ipv6_cidr(input, pos)
+        {
+            return Some(range);
         }
         None
     }
@@ -194,16 +194,16 @@ impl Finder for Cidr {
         let mut idx = 0;
 
         while idx < input.len() {
-            if input[idx].is_ascii_digit() {
-                if let Some(range) = Self::try_ipv4_cidr(input, idx) {
-                    return Some(range);
-                }
+            if input[idx].is_ascii_digit()
+                && let Some(range) = Self::try_ipv4_cidr(input, idx)
+            {
+                return Some(range);
             }
 
-            if input[idx] == b'[' || input[idx].is_ascii_hexdigit() || input[idx] == b':' {
-                if let Some(range) = Self::try_ipv6_cidr(input, idx) {
-                    return Some(range);
-                }
+            if (input[idx] == b'[' || input[idx].is_ascii_hexdigit() || input[idx] == b':')
+                && let Some(range) = Self::try_ipv6_cidr(input, idx)
+            {
+                return Some(range);
             }
 
             idx += 1;

--- a/squeeze/cidr.rs
+++ b/squeeze/cidr.rs
@@ -41,8 +41,8 @@ impl Cidr {
             }
 
             let mut value: u16 = 0;
-            for i in octet_start..pos {
-                value = value * 10 + (input[i] - b'0') as u16;
+            for &b in &input[octet_start..pos] {
+                value = value * 10 + (b - b'0') as u16;
             }
             if value > 255 {
                 return None;
@@ -70,8 +70,8 @@ impl Cidr {
         }
 
         let mut prefix: u8 = 0;
-        for i in prefix_start..pos {
-            prefix = prefix * 10 + (input[i] - b'0') as u8;
+        for &b in &input[prefix_start..pos] {
+            prefix = prefix * 10 + (b - b'0');
         }
         if prefix > 32 {
             return None;
@@ -146,8 +146,8 @@ impl Cidr {
         }
 
         let mut prefix: u16 = 0;
-        for i in prefix_start..pos {
-            prefix = prefix * 10 + (input[i] - b'0') as u16;
+        for &b in &input[prefix_start..pos] {
+            prefix = prefix * 10 + (b - b'0') as u16;
         }
         if prefix > 128 {
             return None;
@@ -160,7 +160,6 @@ impl Cidr {
 
         Some(ip_start..pos)
     }
-
 }
 
 impl Finder for Cidr {

--- a/squeeze/codetag.rs
+++ b/squeeze/codetag.rs
@@ -183,11 +183,7 @@ impl Finder for Codetag {
             m.start()
         };
         let to = s.len();
-        if from >= to {
-            None
-        } else {
-            Some(from..to)
-        }
+        if from >= to { None } else { Some(from..to) }
     }
 }
 

--- a/squeeze/color.rs
+++ b/squeeze/color.rs
@@ -79,11 +79,7 @@ impl Color {
             end += 1;
         }
 
-        if depth == 0 {
-            Some(pos..end)
-        } else {
-            None
-        }
+        if depth == 0 { Some(pos..end) } else { None }
     }
 }
 
@@ -101,15 +97,15 @@ impl Finder for Color {
     }
 
     fn try_at(&self, input: &[u8], pos: usize) -> Option<Range<usize>> {
-        if input[pos] == b'#' {
-            if let Some(range) = Self::try_hex_color(input, pos) {
-                return Some(range);
-            }
+        if input[pos] == b'#'
+            && let Some(range) = Self::try_hex_color(input, pos)
+        {
+            return Some(range);
         }
-        if matches!(input[pos], b'r' | b'R' | b'h' | b'H') {
-            if let Some(range) = Self::try_css_function(input, pos) {
-                return Some(range);
-            }
+        if matches!(input[pos], b'r' | b'R' | b'h' | b'H')
+            && let Some(range) = Self::try_css_function(input, pos)
+        {
+            return Some(range);
         }
         None
     }
@@ -119,16 +115,16 @@ impl Finder for Color {
         let mut idx = 0;
 
         while idx < input.len() {
-            if input[idx] == b'#' {
-                if let Some(range) = Self::try_hex_color(input, idx) {
-                    return Some(range);
-                }
+            if input[idx] == b'#'
+                && let Some(range) = Self::try_hex_color(input, idx)
+            {
+                return Some(range);
             }
 
-            if matches!(input[idx], b'r' | b'R' | b'h' | b'H') {
-                if let Some(range) = Self::try_css_function(input, idx) {
-                    return Some(range);
-                }
+            if matches!(input[idx], b'r' | b'R' | b'h' | b'H')
+                && let Some(range) = Self::try_css_function(input, idx)
+            {
+                return Some(range);
             }
 
             idx += 1;

--- a/squeeze/color.rs
+++ b/squeeze/color.rs
@@ -92,6 +92,28 @@ impl Finder for Color {
         "color"
     }
 
+    fn dispatchable(&self) -> bool {
+        true
+    }
+
+    fn could_start_at(&self, byte: u8) -> bool {
+        byte == b'#' || matches!(byte, b'r' | b'R' | b'h' | b'H')
+    }
+
+    fn try_at(&self, input: &[u8], pos: usize) -> Option<Range<usize>> {
+        if input[pos] == b'#' {
+            if let Some(range) = Self::try_hex_color(input, pos) {
+                return Some(range);
+            }
+        }
+        if matches!(input[pos], b'r' | b'R' | b'h' | b'H') {
+            if let Some(range) = Self::try_css_function(input, pos) {
+                return Some(range);
+            }
+        }
+        None
+    }
+
     fn find(&self, s: &str) -> Option<Range<usize>> {
         let input = s.as_bytes();
         let mut idx = 0;
@@ -262,5 +284,68 @@ mod tests {
         let input = "background-color: #333;";
         let range = finder.find(input).unwrap();
         assert_eq!("#333", &input[range]);
+    }
+
+    #[test]
+    fn try_at_hex_color() {
+        let finder = Color::default();
+        let input = b"#ff00aa rest";
+        assert_eq!(finder.try_at(input, 0), Some(0..7));
+    }
+
+    #[test]
+    fn try_at_rgb_function() {
+        let finder = Color::default();
+        let input = b"rgb(255, 0, 0) rest";
+        assert_eq!(finder.try_at(input, 0), Some(0..14));
+    }
+
+    #[test]
+    fn try_at_hsl_function() {
+        let finder = Color::default();
+        let input = b"hsl(120, 100%, 50%) rest";
+        assert_eq!(finder.try_at(input, 0), Some(0..19));
+    }
+
+    #[test]
+    fn try_at_rejects_bare_hash() {
+        let finder = Color::default();
+        let input = b"# not a color";
+        assert!(finder.try_at(input, 0).is_none());
+    }
+
+    #[test]
+    fn try_at_rejects_too_many_hex() {
+        let finder = Color::default();
+        let input = b"#123456789";
+        assert!(finder.try_at(input, 0).is_none());
+    }
+
+    #[test]
+    fn find_css_case_insensitive() {
+        let finder = Color::default();
+        let input = "RGB(1, 2, 3)";
+        assert!(finder.find(input).is_some());
+        let input = "HSL(0, 0%, 0%)";
+        assert!(finder.find(input).is_some());
+    }
+
+    #[test]
+    fn find_hash_only() {
+        let finder = Color::default();
+        assert!(finder.find("#").is_none());
+    }
+
+    #[test]
+    fn find_hash_two_hex() {
+        let finder = Color::default();
+        assert!(finder.find("#ab").is_none());
+    }
+
+    #[test]
+    fn try_at_non_color_byte() {
+        let finder = Color::default();
+        let input = b"xyz";
+        assert!(finder.try_at(input, 0).is_none());
     }
 }

--- a/squeeze/datetime.rs
+++ b/squeeze/datetime.rs
@@ -54,12 +54,13 @@ impl Datetime {
         let mut end = idx + 10;
 
         // Optional time component: T or space followed by HH:MM
-        if end < input.len() && (input[end] == b'T' || input[end] == b' ') {
-            if let Some(time_end) = Self::try_time(input, end + 1) {
-                // Only accept space separator if it's 'T' or if followed by valid time
-                if input[end] == b'T' || time_end > end + 1 {
-                    end = time_end;
-                }
+        if end < input.len()
+            && (input[end] == b'T' || input[end] == b' ')
+            && let Some(time_end) = Self::try_time(input, end + 1)
+        {
+            // Only accept space separator if it's 'T' or if followed by valid time
+            if input[end] == b'T' || time_end > end + 1 {
+                end = time_end;
             }
         }
 
@@ -180,10 +181,10 @@ impl Finder for Datetime {
         let mut idx = 0;
 
         while idx + 10 <= input.len() {
-            if input[idx].is_ascii_digit() {
-                if let Some(range) = Self::try_date(input, idx) {
-                    return Some(range);
-                }
+            if input[idx].is_ascii_digit()
+                && let Some(range) = Self::try_date(input, idx)
+            {
+                return Some(range);
             }
             idx += 1;
         }

--- a/squeeze/datetime.rs
+++ b/squeeze/datetime.rs
@@ -20,7 +20,7 @@ impl Datetime {
         if !Self::is_4_digits(input, idx) {
             return None;
         }
-        let year = Self::parse_num(input, idx, 4)?;
+        let year = Self::parse_num(input, idx, 4);
         if !(1000..=9999).contains(&year) {
             return None;
         }
@@ -33,7 +33,7 @@ impl Datetime {
         if !Self::is_2_digits(input, idx + 5) {
             return None;
         }
-        let month = Self::parse_num(input, idx + 5, 2)?;
+        let month = Self::parse_num(input, idx + 5, 2);
         if !(1..=12).contains(&month) {
             return None;
         }
@@ -46,7 +46,7 @@ impl Datetime {
         if !Self::is_2_digits(input, idx + 8) {
             return None;
         }
-        let day = Self::parse_num(input, idx + 8, 2)?;
+        let day = Self::parse_num(input, idx + 8, 2);
         if !(1..=31).contains(&day) {
             return None;
         }
@@ -80,7 +80,7 @@ impl Datetime {
         if !Self::is_2_digits(input, idx) {
             return None;
         }
-        let hour = Self::parse_num(input, idx, 2)?;
+        let hour = Self::parse_num(input, idx, 2);
         if hour > 23 {
             return None;
         }
@@ -92,7 +92,7 @@ impl Datetime {
         if !Self::is_2_digits(input, idx + 3) {
             return None;
         }
-        let minute = Self::parse_num(input, idx + 3, 2)?;
+        let minute = Self::parse_num(input, idx + 3, 2);
         if minute > 59 {
             return None;
         }
@@ -101,7 +101,7 @@ impl Datetime {
 
         // Optional :SS
         if end + 3 <= input.len() && input[end] == b':' && Self::is_2_digits(input, end + 1) {
-            let second = Self::parse_num(input, end + 1, 2)?;
+            let second = Self::parse_num(input, end + 1, 2);
             if second <= 60 {
                 end += 3;
 
@@ -146,17 +146,33 @@ impl Datetime {
             && input[pos + 3].is_ascii_digit()
     }
 
-    fn parse_num(input: &[u8], pos: usize, len: usize) -> Option<u32> {
-        std::str::from_utf8(&input[pos..pos + len])
-            .ok()?
-            .parse()
-            .ok()
+    fn parse_num(input: &[u8], pos: usize, len: usize) -> u32 {
+        let mut n = 0u32;
+        for i in 0..len {
+            n = n * 10 + (input[pos + i] - b'0') as u32;
+        }
+        n
     }
 }
 
 impl Finder for Datetime {
     fn id(&self) -> &'static str {
         "datetime"
+    }
+
+    fn dispatchable(&self) -> bool {
+        true
+    }
+
+    fn could_start_at(&self, byte: u8) -> bool {
+        byte.is_ascii_digit()
+    }
+
+    fn try_at(&self, input: &[u8], pos: usize) -> Option<Range<usize>> {
+        if !input[pos].is_ascii_digit() {
+            return None;
+        }
+        Self::try_date(input, pos)
     }
 
     fn find(&self, s: &str) -> Option<Range<usize>> {
@@ -360,5 +376,69 @@ mod tests {
         let input = "log: 2024-01-15 10:30:00";
         let range = finder.find(input).unwrap();
         assert_eq!("2024-01-15 10:30:00", &input[range]);
+    }
+
+    #[test]
+    fn try_at_date_at_start() {
+        let finder = Datetime::default();
+        let input = b"2024-01-15 rest";
+        assert_eq!(finder.try_at(input, 0), Some(0..10));
+    }
+
+    #[test]
+    fn try_at_non_digit() {
+        let finder = Datetime::default();
+        let input = b"abc";
+        assert!(finder.try_at(input, 0).is_none());
+    }
+
+    #[test]
+    fn try_at_short_input() {
+        let finder = Datetime::default();
+        let input = b"2024";
+        assert!(finder.try_at(input, 0).is_none());
+    }
+
+    #[test]
+    fn try_at_preceded_by_digit() {
+        let finder = Datetime::default();
+        let input = b"12024-01-15";
+        assert!(finder.try_at(input, 1).is_none());
+    }
+
+    #[test]
+    fn find_boundary_year_1000() {
+        let finder = Datetime::default();
+        let input = "1000-01-01";
+        assert!(finder.find(input).is_some());
+    }
+
+    #[test]
+    fn find_boundary_year_9999() {
+        let finder = Datetime::default();
+        let input = "9999-12-31";
+        assert!(finder.find(input).is_some());
+    }
+
+    #[test]
+    fn find_leap_second() {
+        let finder = Datetime::default();
+        let input = "2024-06-30T23:59:60Z";
+        let range = finder.find(input).unwrap();
+        assert_eq!("2024-06-30T23:59:60Z", &input[range]);
+    }
+
+    #[test]
+    fn find_fractional_seconds_many_digits() {
+        let finder = Datetime::default();
+        let input = "2024-01-15T10:30:00.123456789Z";
+        let range = finder.find(input).unwrap();
+        assert_eq!("2024-01-15T10:30:00.123456789Z", &input[range]);
+    }
+
+    #[test]
+    fn find_single_digit_input() {
+        let finder = Datetime::default();
+        assert!(finder.find("1").is_none());
     }
 }

--- a/squeeze/email.rs
+++ b/squeeze/email.rs
@@ -1,12 +1,13 @@
 use super::Finder;
+use memchr::memchr;
 use std::ops::Range;
 
-#[derive(Default)]
-pub struct Email {}
-
-impl Email {
-    fn is_local_char(b: u8) -> bool {
-        b.is_ascii_alphanumeric()
+const LOCAL_CHARS: [bool; 256] = {
+    let mut table = [false; 256];
+    let mut i = 0u16;
+    while i < 256 {
+        let b = i as u8;
+        table[i as usize] = b.is_ascii_alphanumeric()
             || matches!(
                 b,
                 b'.' | b'!'
@@ -28,9 +29,14 @@ impl Email {
                     | b'}'
                     | b'~'
                     | b'-'
-            )
+            );
+        i += 1;
     }
-}
+    table
+};
+
+#[derive(Default)]
+pub struct Email {}
 
 impl Finder for Email {
     fn id(&self) -> &'static str {
@@ -42,11 +48,10 @@ impl Finder for Email {
         let mut idx = 0;
 
         while idx < input.len() {
-            let at_pos = idx + input[idx..].iter().position(|&b| b == b'@')?;
+            let at_pos = idx + memchr(b'@', &input[idx..])?;
 
-            // Walk backwards for local part
             let mut local_start = at_pos;
-            while local_start > idx && Self::is_local_char(input[local_start - 1]) {
+            while local_start > idx && LOCAL_CHARS[input[local_start - 1] as usize] {
                 local_start -= 1;
             }
 

--- a/squeeze/email.rs
+++ b/squeeze/email.rs
@@ -1,5 +1,4 @@
 use super::Finder;
-use memchr::memchr;
 use std::ops::Range;
 
 const LOCAL_CHARS: [bool; 256] = {
@@ -48,7 +47,7 @@ impl Finder for Email {
         let mut idx = 0;
 
         while idx < input.len() {
-            let at_pos = idx + memchr(b'@', &input[idx..])?;
+            let at_pos = idx + input[idx..].iter().position(|&b| b == b'@')?;
 
             let mut local_start = at_pos;
             while local_start > idx && LOCAL_CHARS[input[local_start - 1] as usize] {

--- a/squeeze/email.rs
+++ b/squeeze/email.rs
@@ -61,53 +61,78 @@ impl Finder for Email {
                 continue;
             }
 
-            // Walk forwards for domain
+            // Walk forwards for domain, validating in a single pass
             let domain_start = at_pos + 1;
             let mut domain_end = domain_start;
-            while domain_end < input.len()
-                && (input[domain_end].is_ascii_alphanumeric()
-                    || input[domain_end] == b'-'
-                    || input[domain_end] == b'.')
-            {
-                domain_end += 1;
+            let mut dot_count = 0u32;
+            let mut last_dot = 0usize;
+            let mut label_start = domain_start;
+            let mut label_valid = true;
+
+            while domain_end < input.len() {
+                let b = input[domain_end];
+                if b == b'.' {
+                    let label_len = domain_end - label_start;
+                    if label_len == 0 || input[label_start] == b'-' || input[domain_end - 1] == b'-'
+                    {
+                        label_valid = false;
+                        break;
+                    }
+                    dot_count += 1;
+                    last_dot = domain_end;
+                    label_start = domain_end + 1;
+                    domain_end += 1;
+                } else if b.is_ascii_alphanumeric() || b == b'-' {
+                    domain_end += 1;
+                } else {
+                    break;
+                }
             }
 
-            if domain_end == domain_start {
+            if domain_end == domain_start || !label_valid {
                 idx = at_pos + 1;
                 continue;
             }
 
             // Strip trailing dots/hyphens
             while domain_end > domain_start && matches!(input[domain_end - 1], b'.' | b'-') {
+                if input[domain_end - 1] == b'.' && domain_end - 1 == last_dot {
+                    dot_count -= 1;
+                    if dot_count > 0 {
+                        // Recalculate last_dot
+                        last_dot = input[domain_start..domain_end - 1]
+                            .iter()
+                            .rposition(|&b| b == b'.')
+                            .map(|p| domain_start + p)
+                            .unwrap_or(0);
+                    }
+                }
                 domain_end -= 1;
             }
 
-            let domain = &s[domain_start..domain_end];
-
-            // Must have at least one dot
-            if !domain.contains('.') {
+            if dot_count == 0 {
                 idx = at_pos + 1;
                 continue;
             }
 
-            // Validate each label
-            let valid = domain.split('.').all(|label| {
-                !label.is_empty()
-                    && !label.starts_with('-')
-                    && !label.ends_with('-')
-                    && label
-                        .bytes()
-                        .all(|b| b.is_ascii_alphanumeric() || b == b'-')
-            });
-
-            if !valid {
+            // Validate final label (after last strip)
+            let final_label_start = if last_dot >= domain_start {
+                last_dot + 1
+            } else {
+                domain_start
+            };
+            let final_label_len = domain_end - final_label_start;
+            if final_label_len == 0
+                || input[final_label_start] == b'-'
+                || input[domain_end - 1] == b'-'
+            {
                 idx = at_pos + 1;
                 continue;
             }
 
             // TLD must be >= 2 chars and all alpha
-            let tld = domain.rsplit('.').next().unwrap();
-            if tld.len() < 2 || !tld.bytes().all(|b| b.is_ascii_alphabetic()) {
+            let tld = &input[last_dot + 1..domain_end];
+            if tld.len() < 2 || !tld.iter().all(|b| b.is_ascii_alphabetic()) {
                 idx = at_pos + 1;
                 continue;
             }
@@ -292,5 +317,65 @@ mod tests {
         let input = "@invalid then real@example.com";
         let range = finder.find(input).unwrap();
         assert_eq!("real@example.com", &input[range]);
+    }
+
+    // --- Regression: single-pass domain validation ---
+
+    #[test]
+    fn find_should_handle_domain_with_many_labels() {
+        let finder = Email::default();
+        let input = "user@a.b.c.d.example.com";
+        let range = finder.find(input).unwrap();
+        assert_eq!("user@a.b.c.d.example.com", &input[range]);
+    }
+
+    #[test]
+    fn find_should_reject_consecutive_dots_in_domain() {
+        let finder = Email::default();
+        assert!(finder.find("user@example..com").is_none());
+    }
+
+    #[test]
+    fn find_should_strip_trailing_dot_from_domain() {
+        let finder = Email::default();
+        let input = "user@example.com.";
+        let range = finder.find(input).unwrap();
+        assert_eq!("user@example.com", &input[range]);
+    }
+
+    #[test]
+    fn find_should_handle_trailing_dot_strip_and_still_validate() {
+        let finder = Email::default();
+        let input = "user@example.com. next";
+        let range = finder.find(input).unwrap();
+        assert_eq!("user@example.com", &input[range]);
+    }
+
+    #[test]
+    fn find_should_reject_label_starting_with_hyphen_deep() {
+        let finder = Email::default();
+        assert!(finder.find("user@sub.-example.com").is_none());
+    }
+
+    #[test]
+    fn find_should_reject_label_ending_with_hyphen_deep() {
+        let finder = Email::default();
+        assert!(finder.find("user@sub.example-.com").is_none());
+    }
+
+    #[test]
+    fn find_should_handle_max_length_tld() {
+        let finder = Email::default();
+        let input = "user@example.museum";
+        let range = finder.find(input).unwrap();
+        assert_eq!("user@example.museum", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_email_adjacent_to_punctuation() {
+        let finder = Email::default();
+        let input = "email:user@example.com,next";
+        let range = finder.find(input).unwrap();
+        assert_eq!("user@example.com", &input[range]);
     }
 }

--- a/squeeze/emoji.rs
+++ b/squeeze/emoji.rs
@@ -381,4 +381,67 @@ mod tests {
         let range = finder.find(input).unwrap();
         assert_eq!("😀", &input[range]);
     }
+
+    // --- Regression: try_at with unchecked UTF-8 ---
+
+    #[test]
+    fn try_at_simple_emoji() {
+        let finder = Emoji::default();
+        let input = "😀 rest".as_bytes();
+        let range = finder.try_at(input, 0).unwrap();
+        assert_eq!(range, 0..4);
+    }
+
+    #[test]
+    fn try_at_emoji_after_ascii() {
+        let finder = Emoji::default();
+        let input = "hi 😀 rest";
+        let bytes = input.as_bytes();
+        let range = finder.try_at(bytes, 3).unwrap();
+        assert_eq!(&input[range], "😀");
+    }
+
+    #[test]
+    fn try_at_emoji_with_skin_tone() {
+        let finder = Emoji::default();
+        let input = "👋🏽";
+        let bytes = input.as_bytes();
+        let range = finder.try_at(bytes, 0).unwrap();
+        assert_eq!(&input[range], "👋🏽");
+    }
+
+    #[test]
+    fn try_at_non_emoji_multibyte() {
+        let finder = Emoji::default();
+        let input = "héllo";
+        let bytes = input.as_bytes();
+        assert!(finder.try_at(bytes, 0).is_none());
+    }
+
+    #[test]
+    fn try_at_zwj_sequence_via_dispatch() {
+        let finder = Emoji::default();
+        let input = "👨\u{200D}👩\u{200D}👧";
+        let bytes = input.as_bytes();
+        let range = finder.try_at(bytes, 0).unwrap();
+        assert_eq!(&input[range], "👨\u{200D}👩\u{200D}👧");
+    }
+
+    #[test]
+    fn try_at_flag_sequence() {
+        let finder = Emoji::default();
+        let input = "🇺🇸";
+        let bytes = input.as_bytes();
+        let range = finder.try_at(bytes, 0).unwrap();
+        assert_eq!(&input[range], "🇺🇸");
+    }
+
+    #[test]
+    fn try_at_does_not_start_mid_zwj() {
+        let finder = Emoji::default();
+        let input = "👨\u{200D}👩";
+        let bytes = input.as_bytes();
+        let emoji2_start = "👨\u{200D}".len();
+        assert!(finder.try_at(bytes, emoji2_start).is_none());
+    }
 }

--- a/squeeze/emoji.rs
+++ b/squeeze/emoji.rs
@@ -1,0 +1,385 @@
+use super::Finder;
+use std::ops::Range;
+
+#[derive(Default)]
+pub struct Emoji {}
+
+impl Emoji {
+    fn is_emoji(c: char) -> bool {
+        let cp = c as u32;
+        if (0x1F000..=0x1FAFF).contains(&cp) {
+            return true;
+        }
+        if (0x2600..=0x27BF).contains(&cp) {
+            return true;
+        }
+        matches!(
+            cp,
+            0x203C
+                | 0x2049
+                | 0x2122
+                | 0x2139
+                | 0x2194..=0x2199
+                | 0x21A9..=0x21AA
+                | 0x231A..=0x231B
+                | 0x2328
+                | 0x23CF
+                | 0x23E9..=0x23F3
+                | 0x23F8..=0x23FA
+                | 0x24C2
+                | 0x25AA..=0x25AB
+                | 0x25B6
+                | 0x25C0
+                | 0x25FB..=0x25FE
+                | 0x2934..=0x2935
+                | 0x2B05..=0x2B07
+                | 0x2B1B..=0x2B1C
+                | 0x2B50
+                | 0x2B55
+                | 0x3030
+                | 0x303D
+                | 0x3297
+                | 0x3299
+        )
+    }
+
+    fn is_regional_indicator(c: char) -> bool {
+        (0x1F1E6..=0x1F1FF).contains(&(c as u32))
+    }
+
+    fn is_skin_tone(c: char) -> bool {
+        (0x1F3FB..=0x1F3FF).contains(&(c as u32))
+    }
+
+    fn is_zwj(c: char) -> bool {
+        c == '\u{200D}'
+    }
+
+    fn is_variation_selector(c: char) -> bool {
+        c == '\u{FE0F}'
+    }
+
+    fn is_tag_char(c: char) -> bool {
+        (0xE0020..=0xE007E).contains(&(c as u32))
+    }
+
+    fn is_tag_cancel(c: char) -> bool {
+        c == '\u{E007F}'
+    }
+
+    fn consume_sequence(s: &str) -> usize {
+        let mut iter = s.char_indices().peekable();
+
+        let first = match iter.next() {
+            Some((_, c)) => c,
+            None => return 0,
+        };
+
+        let mut end = first.len_utf8();
+
+        if Self::is_regional_indicator(first) {
+            if let Some(&(pos, c)) = iter.peek() {
+                if Self::is_regional_indicator(c) {
+                    end = pos + c.len_utf8();
+                }
+            }
+            return end;
+        }
+
+        if first == '\u{1F3F4}' {
+            let saved = iter.clone();
+            let mut has_tags = false;
+            let mut tag_end = end;
+            loop {
+                match iter.peek() {
+                    Some(&(pos, c)) if Self::is_tag_char(c) => {
+                        has_tags = true;
+                        tag_end = pos + c.len_utf8();
+                        iter.next();
+                    }
+                    Some(&(pos, c)) if Self::is_tag_cancel(c) => {
+                        has_tags = true;
+                        tag_end = pos + c.len_utf8();
+                        iter.next();
+                        break;
+                    }
+                    _ => break,
+                }
+            }
+            if has_tags {
+                return tag_end;
+            }
+            iter = saved;
+        }
+
+        loop {
+            if let Some(&(pos, c)) = iter.peek() {
+                if Self::is_variation_selector(c) {
+                    end = pos + c.len_utf8();
+                    iter.next();
+                }
+            }
+
+            if let Some(&(pos, c)) = iter.peek() {
+                if Self::is_skin_tone(c) {
+                    end = pos + c.len_utf8();
+                    iter.next();
+                }
+            }
+
+            if let Some(&(_, c)) = iter.peek() {
+                if Self::is_zwj(c) {
+                    let mut peek = iter.clone();
+                    peek.next();
+                    if let Some(&(pos, c)) = peek.peek() {
+                        if Self::is_emoji(c) && !Self::is_zwj(c) {
+                            end = pos + c.len_utf8();
+                            peek.next();
+                            iter = peek;
+                            continue;
+                        }
+                    }
+                }
+            }
+
+            break;
+        }
+
+        end
+    }
+}
+
+impl Finder for Emoji {
+    fn id(&self) -> &'static str {
+        "emoji"
+    }
+
+    fn dispatchable(&self) -> bool {
+        true
+    }
+
+    fn could_start_at(&self, byte: u8) -> bool {
+        matches!(byte, 0xE2 | 0xE3 | 0xF0)
+    }
+
+    fn try_at(&self, input: &[u8], pos: usize) -> Option<Range<usize>> {
+        let s = std::str::from_utf8(&input[pos..]).ok()?;
+        let c = s.chars().next()?;
+
+        if !Self::is_emoji(c) || Self::is_zwj(c) {
+            return None;
+        }
+
+        if pos > 0 {
+            if let Ok(before) = std::str::from_utf8(&input[..pos]) {
+                if let Some(prev) = before.chars().last() {
+                    if Self::is_zwj(prev) {
+                        return None;
+                    }
+                }
+            }
+        }
+
+        let end = Self::consume_sequence(s);
+        if end > 0 {
+            Some(pos..pos + end)
+        } else {
+            None
+        }
+    }
+
+    fn find(&self, s: &str) -> Option<Range<usize>> {
+        for (byte_pos, c) in s.char_indices() {
+            if Self::is_emoji(c) && !Self::is_zwj(c) {
+                let end = Self::consume_sequence(&s[byte_pos..]);
+                if end > 0 {
+                    return Some(byte_pos..byte_pos + end);
+                }
+            }
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn id_should_return_emoji() {
+        let finder = Emoji::default();
+        assert_eq!("emoji", finder.id());
+    }
+
+    #[test]
+    fn find_should_extract_simple_emoji() {
+        let finder = Emoji::default();
+        let input = "hello 😀 world";
+        let range = finder.find(input).unwrap();
+        assert_eq!("😀", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_emoji_at_start() {
+        let finder = Emoji::default();
+        let input = "🎉 party";
+        let range = finder.find(input).unwrap();
+        assert_eq!("🎉", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_emoji_at_end() {
+        let finder = Emoji::default();
+        let input = "done ✅";
+        let range = finder.find(input).unwrap();
+        assert_eq!("✅", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_emoji_with_skin_tone() {
+        let finder = Emoji::default();
+        let input = "wave 👋🏽 here";
+        let range = finder.find(input).unwrap();
+        assert_eq!("👋🏽", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_zwj_sequence() {
+        let finder = Emoji::default();
+        let input = "family 👨\u{200D}👩\u{200D}👧 end";
+        let range = finder.find(input).unwrap();
+        assert_eq!("👨\u{200D}👩\u{200D}👧", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_flag() {
+        let finder = Emoji::default();
+        let input = "flag 🇺🇸 end";
+        let range = finder.find(input).unwrap();
+        assert_eq!("🇺🇸", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_emoji_with_variation_selector() {
+        let finder = Emoji::default();
+        let input = "heart ❤\u{FE0F} end";
+        let range = finder.find(input).unwrap();
+        assert_eq!("❤\u{FE0F}", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_tag_sequence() {
+        let finder = Emoji::default();
+        let input =
+            "flag 🏴\u{E0067}\u{E0062}\u{E0065}\u{E006E}\u{E0067}\u{E007F} end";
+        let range = finder.find(input).unwrap();
+        assert_eq!(
+            "🏴\u{E0067}\u{E0062}\u{E0065}\u{E006E}\u{E0067}\u{E007F}",
+            &input[range]
+        );
+    }
+
+    #[test]
+    fn find_should_extract_zwj_with_skin_tone() {
+        let finder = Emoji::default();
+        let input = "👩🏽\u{200D}🔬 scientist";
+        let range = finder.find(input).unwrap();
+        assert_eq!("👩🏽\u{200D}🔬", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_zwj_with_variation_selector() {
+        let finder = Emoji::default();
+        let input = "❤\u{FE0F}\u{200D}🔥";
+        let range = finder.find(input).unwrap();
+        assert_eq!("❤\u{FE0F}\u{200D}🔥", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_multiple_emojis_iteratively() {
+        let finder = Emoji::default();
+        let input = "😀🎉✅";
+
+        let mut results = Vec::new();
+        let mut idx = 0;
+        while idx < input.len() {
+            if let Some(range) = finder.find(&input[idx..]) {
+                results.push(&input[idx + range.start..idx + range.end]);
+                idx += range.end;
+            } else {
+                break;
+            }
+        }
+
+        assert_eq!(vec!["😀", "🎉", "✅"], results);
+    }
+
+    #[test]
+    fn find_should_extract_adjacent_flags() {
+        let finder = Emoji::default();
+        let input = "🇺🇸🇬🇧";
+
+        let mut results = Vec::new();
+        let mut idx = 0;
+        while idx < input.len() {
+            if let Some(range) = finder.find(&input[idx..]) {
+                results.push(&input[idx + range.start..idx + range.end]);
+                idx += range.end;
+            } else {
+                break;
+            }
+        }
+
+        assert_eq!(vec!["🇺🇸", "🇬🇧"], results);
+    }
+
+    #[test]
+    fn find_should_handle_empty_input() {
+        let finder = Emoji::default();
+        assert!(finder.find("").is_none());
+    }
+
+    #[test]
+    fn find_should_reject_plain_ascii() {
+        let finder = Emoji::default();
+        assert!(finder.find("hello world 123").is_none());
+    }
+
+    #[test]
+    fn find_should_not_start_with_zwj() {
+        let finder = Emoji::default();
+        assert!(finder.find("\u{200D}hello").is_none());
+    }
+
+    #[test]
+    fn find_should_extract_misc_symbol() {
+        let finder = Emoji::default();
+        let input = "sun ☀ here";
+        let range = finder.find(input).unwrap();
+        assert_eq!("☀", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_dingbat() {
+        let finder = Emoji::default();
+        let input = "check ✂ here";
+        let range = finder.find(input).unwrap();
+        assert_eq!("✂", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_supplemental_arrow() {
+        let finder = Emoji::default();
+        let input = "go ➡ there";
+        let range = finder.find(input).unwrap();
+        assert_eq!("➡", &input[range]);
+    }
+
+    #[test]
+    fn find_should_extract_emoji_in_brackets() {
+        let finder = Emoji::default();
+        let input = "[😀]";
+        let range = finder.find(input).unwrap();
+        assert_eq!("😀", &input[range]);
+    }
+}

--- a/squeeze/emoji.rs
+++ b/squeeze/emoji.rs
@@ -78,10 +78,10 @@ impl Emoji {
         let mut end = first.len_utf8();
 
         if Self::is_regional_indicator(first) {
-            if let Some(&(pos, c)) = iter.peek() {
-                if Self::is_regional_indicator(c) {
-                    end = pos + c.len_utf8();
-                }
+            if let Some(&(pos, c)) = iter.peek()
+                && Self::is_regional_indicator(c)
+            {
+                end = pos + c.len_utf8();
             }
             return end;
         }
@@ -113,32 +113,33 @@ impl Emoji {
         }
 
         loop {
-            if let Some(&(pos, c)) = iter.peek() {
-                if Self::is_variation_selector(c) {
-                    end = pos + c.len_utf8();
-                    iter.next();
-                }
+            if let Some(&(pos, c)) = iter.peek()
+                && Self::is_variation_selector(c)
+            {
+                end = pos + c.len_utf8();
+                iter.next();
             }
 
-            if let Some(&(pos, c)) = iter.peek() {
-                if Self::is_skin_tone(c) {
-                    end = pos + c.len_utf8();
-                    iter.next();
-                }
+            if let Some(&(pos, c)) = iter.peek()
+                && Self::is_skin_tone(c)
+            {
+                end = pos + c.len_utf8();
+                iter.next();
             }
 
-            if let Some(&(_, c)) = iter.peek() {
-                if Self::is_zwj(c) {
-                    let mut peek = iter.clone();
+            if let Some(&(_, c)) = iter.peek()
+                && Self::is_zwj(c)
+            {
+                let mut peek = iter.clone();
+                peek.next();
+                if let Some(&(pos, c)) = peek.peek()
+                    && Self::is_emoji(c)
+                    && !Self::is_zwj(c)
+                {
+                    end = pos + c.len_utf8();
                     peek.next();
-                    if let Some(&(pos, c)) = peek.peek() {
-                        if Self::is_emoji(c) && !Self::is_zwj(c) {
-                            end = pos + c.len_utf8();
-                            peek.next();
-                            iter = peek;
-                            continue;
-                        }
-                    }
+                    iter = peek;
+                    continue;
                 }
             }
 
@@ -170,22 +171,16 @@ impl Finder for Emoji {
             return None;
         }
 
-        if pos > 0 {
-            if let Ok(before) = std::str::from_utf8(&input[..pos]) {
-                if let Some(prev) = before.chars().last() {
-                    if Self::is_zwj(prev) {
-                        return None;
-                    }
-                }
-            }
+        if pos > 0
+            && let Ok(before) = std::str::from_utf8(&input[..pos])
+            && let Some(prev) = before.chars().last()
+            && Self::is_zwj(prev)
+        {
+            return None;
         }
 
         let end = Self::consume_sequence(s);
-        if end > 0 {
-            Some(pos..pos + end)
-        } else {
-            None
-        }
+        if end > 0 { Some(pos..pos + end) } else { None }
     }
 
     fn find(&self, s: &str) -> Option<Range<usize>> {

--- a/squeeze/emoji.rs
+++ b/squeeze/emoji.rs
@@ -270,8 +270,7 @@ mod tests {
     #[test]
     fn find_should_extract_tag_sequence() {
         let finder = Emoji::default();
-        let input =
-            "flag 🏴\u{E0067}\u{E0062}\u{E0065}\u{E006E}\u{E0067}\u{E007F} end";
+        let input = "flag 🏴\u{E0067}\u{E0062}\u{E0065}\u{E006E}\u{E0067}\u{E007F} end";
         let range = finder.find(input).unwrap();
         assert_eq!(
             "🏴\u{E0067}\u{E0062}\u{E0065}\u{E006E}\u{E0067}\u{E007F}",

--- a/squeeze/env.rs
+++ b/squeeze/env.rs
@@ -19,6 +19,45 @@ impl Finder for Env {
         "env"
     }
 
+    fn dispatchable(&self) -> bool {
+        true
+    }
+
+    fn could_start_at(&self, byte: u8) -> bool {
+        byte == b'$'
+    }
+
+    fn try_at(&self, input: &[u8], pos: usize) -> Option<Range<usize>> {
+        if input[pos] != b'$' {
+            return None;
+        }
+        let after = pos + 1;
+        if after >= input.len() {
+            return None;
+        }
+        if input[after] == b'{' {
+            let name_start = after + 1;
+            if name_start < input.len() && Self::is_name_start(input[name_start]) {
+                let mut name_end = name_start + 1;
+                while name_end < input.len() && Self::is_name_char(input[name_end]) {
+                    name_end += 1;
+                }
+                if name_end < input.len() && input[name_end] == b'}' {
+                    return Some(pos..name_end + 1);
+                }
+            }
+            return None;
+        }
+        if Self::is_name_start(input[after]) {
+            let mut name_end = after + 1;
+            while name_end < input.len() && Self::is_name_char(input[name_end]) {
+                name_end += 1;
+            }
+            return Some(pos..name_end);
+        }
+        None
+    }
+
     fn find(&self, s: &str) -> Option<Range<usize>> {
         let input = s.as_bytes();
         let mut idx = 0;
@@ -194,5 +233,70 @@ mod tests {
         let input = r#"echo "$HOME""#;
         let range = finder.find(input).unwrap();
         assert_eq!("$HOME", &input[range]);
+    }
+
+    #[test]
+    fn try_at_simple_var() {
+        let finder = Env::default();
+        assert_eq!(finder.try_at(b"$HOME rest", 0), Some(0..5));
+    }
+
+    #[test]
+    fn try_at_braced_var() {
+        let finder = Env::default();
+        assert_eq!(finder.try_at(b"${PATH}", 0), Some(0..7));
+    }
+
+    #[test]
+    fn try_at_rejects_non_dollar() {
+        let finder = Env::default();
+        assert!(finder.try_at(b"HOME", 0).is_none());
+    }
+
+    #[test]
+    fn try_at_dollar_at_end() {
+        let finder = Env::default();
+        assert!(finder.try_at(b"$", 0).is_none());
+    }
+
+    #[test]
+    fn try_at_dollar_digit() {
+        let finder = Env::default();
+        assert!(finder.try_at(b"$1", 0).is_none());
+    }
+
+    #[test]
+    fn try_at_unclosed_brace() {
+        let finder = Env::default();
+        assert!(finder.try_at(b"${FOO", 0).is_none());
+    }
+
+    #[test]
+    fn try_at_empty_brace() {
+        let finder = Env::default();
+        assert!(finder.try_at(b"${}", 0).is_none());
+    }
+
+    #[test]
+    fn find_adjacent_vars() {
+        let finder = Env::default();
+        let input = "$A$B";
+        let mut results = Vec::new();
+        let mut idx = 0;
+        while idx < input.len() {
+            if let Some(range) = finder.find(&input[idx..]) {
+                results.push(&input[idx + range.start..idx + range.end]);
+                idx += range.end;
+            } else {
+                break;
+            }
+        }
+        assert_eq!(results, vec!["$A", "$B"]);
+    }
+
+    #[test]
+    fn find_dollar_space_dollar() {
+        let finder = Env::default();
+        assert!(finder.find("$ $").is_none());
     }
 }

--- a/squeeze/hash.rs
+++ b/squeeze/hash.rs
@@ -37,7 +37,11 @@ impl Hash {
             SHA512_LEN => SHA512_BIT,
             _ => return false,
         };
-        let mask = if self.lengths == 0 { ALL_BITS } else { self.lengths };
+        let mask = if self.lengths == 0 {
+            ALL_BITS
+        } else {
+            self.lengths
+        };
         (mask & bit) != 0
     }
 

--- a/squeeze/hash.rs
+++ b/squeeze/hash.rs
@@ -1,5 +1,4 @@
 use super::Finder;
-use std::collections::HashSet;
 use std::ops::Range;
 
 const MD5_LEN: usize = 32;
@@ -7,31 +6,39 @@ const SHA1_LEN: usize = 40;
 const SHA256_LEN: usize = 64;
 const SHA512_LEN: usize = 128;
 
-const ALL_LENGTHS: &[usize] = &[MD5_LEN, SHA1_LEN, SHA256_LEN, SHA512_LEN];
+const MD5_BIT: u8 = 1;
+const SHA1_BIT: u8 = 2;
+const SHA256_BIT: u8 = 4;
+const SHA512_BIT: u8 = 8;
+const ALL_BITS: u8 = MD5_BIT | SHA1_BIT | SHA256_BIT | SHA512_BIT;
 
 #[derive(Default)]
 pub struct Hash {
-    lengths: HashSet<usize>,
+    lengths: u8,
 }
 
 impl Hash {
     pub fn add_algorithm(&mut self, name: &str) {
-        let len = match name.to_lowercase().as_str() {
-            "md5" => MD5_LEN,
-            "sha1" | "sha-1" => SHA1_LEN,
-            "sha256" | "sha-256" => SHA256_LEN,
-            "sha512" | "sha-512" => SHA512_LEN,
+        let bit = match name.to_lowercase().as_str() {
+            "md5" => MD5_BIT,
+            "sha1" | "sha-1" => SHA1_BIT,
+            "sha256" | "sha-256" => SHA256_BIT,
+            "sha512" | "sha-512" => SHA512_BIT,
             _ => return,
         };
-        self.lengths.insert(len);
+        self.lengths |= bit;
     }
 
     fn is_target_length(&self, len: usize) -> bool {
-        if self.lengths.is_empty() {
-            ALL_LENGTHS.contains(&len)
-        } else {
-            self.lengths.contains(&len)
-        }
+        let bit = match len {
+            MD5_LEN => MD5_BIT,
+            SHA1_LEN => SHA1_BIT,
+            SHA256_LEN => SHA256_BIT,
+            SHA512_LEN => SHA512_BIT,
+            _ => return false,
+        };
+        let mask = if self.lengths == 0 { ALL_BITS } else { self.lengths };
+        (mask & bit) != 0
     }
 
     fn is_hex(b: u8) -> bool {
@@ -42,6 +49,32 @@ impl Hash {
 impl Finder for Hash {
     fn id(&self) -> &'static str {
         "hash"
+    }
+
+    fn dispatchable(&self) -> bool {
+        true
+    }
+
+    fn could_start_at(&self, byte: u8) -> bool {
+        byte.is_ascii_hexdigit()
+    }
+
+    fn try_at(&self, input: &[u8], pos: usize) -> Option<Range<usize>> {
+        if !Self::is_hex(input[pos]) {
+            return None;
+        }
+        if pos > 0 && Self::is_hex(input[pos - 1]) {
+            return None;
+        }
+        let mut end = pos;
+        while end < input.len() && Self::is_hex(input[end]) {
+            end += 1;
+        }
+        if self.is_target_length(end - pos) {
+            Some(pos..end)
+        } else {
+            None
+        }
     }
 
     fn find(&self, s: &str) -> Option<Range<usize>> {
@@ -67,12 +100,6 @@ impl Finder for Hash {
             }
 
             let len = end - start;
-
-            // Check boundary after
-            if end < input.len() && Self::is_hex(input[end]) {
-                idx = end + 1;
-                continue;
-            }
 
             if self.is_target_length(len) {
                 return Some(start..end);
@@ -226,19 +253,61 @@ mod tests {
     fn add_algorithm_should_accept_various_names() {
         let mut finder = Hash::default();
         finder.add_algorithm("sha-256");
-        assert!(finder.lengths.contains(&64));
+        assert!(finder.lengths & SHA256_BIT != 0);
 
         finder.add_algorithm("SHA1");
-        assert!(finder.lengths.contains(&40));
+        assert!(finder.lengths & SHA1_BIT != 0);
 
         finder.add_algorithm("SHA-512");
-        assert!(finder.lengths.contains(&128));
+        assert!(finder.lengths & SHA512_BIT != 0);
     }
 
     #[test]
     fn add_algorithm_should_ignore_unknown() {
         let mut finder = Hash::default();
         finder.add_algorithm("blake2");
-        assert!(finder.lengths.is_empty());
+        assert_eq!(0, finder.lengths);
+    }
+
+    #[test]
+    fn try_at_matches_find_at_start() {
+        let finder = Hash::default();
+        let input = b"5d41402abc4b2a76b9719d911017c592 trail";
+        assert!(finder.try_at(input, 0).is_some());
+        assert_eq!(finder.try_at(input, 0).unwrap(), 0..32);
+    }
+
+    #[test]
+    fn try_at_rejects_mid_hex_run() {
+        let finder = Hash::default();
+        let input = b"a5d41402abc4b2a76b9719d911017c592";
+        assert!(finder.try_at(input, 1).is_none());
+    }
+
+    #[test]
+    fn try_at_at_last_byte() {
+        let finder = Hash::default();
+        let input = b"x";
+        assert!(finder.try_at(input, 0).is_none());
+    }
+
+    #[test]
+    fn try_at_single_hex_byte() {
+        let finder = Hash::default();
+        let input = b"a";
+        assert!(finder.try_at(input, 0).is_none());
+    }
+
+    #[test]
+    fn find_should_not_match_non_hex_chars() {
+        let finder = Hash::default();
+        assert!(finder.find("zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz").is_none());
+    }
+
+    #[test]
+    fn find_should_match_all_hex_letters() {
+        let finder = Hash::default();
+        let input = "abcdefABCDEFabcdefABCDEFabcdefAB";
+        assert_eq!(finder.find(input).unwrap(), 0..32);
     }
 }

--- a/squeeze/ip.rs
+++ b/squeeze/ip.rs
@@ -51,8 +51,8 @@ impl Ip {
             }
 
             let mut value: u16 = 0;
-            for i in octet_start..pos {
-                value = value * 10 + (input[i] - b'0') as u16;
+            for &b in &input[octet_start..pos] {
+                value = value * 10 + (b - b'0') as u16;
             }
             if value > 255 {
                 return None;
@@ -126,7 +126,6 @@ impl Ip {
             None
         }
     }
-
 }
 
 impl Finder for Ip {
@@ -140,8 +139,7 @@ impl Finder for Ip {
 
     fn could_start_at(&self, byte: u8) -> bool {
         (self.ipv4 && byte.is_ascii_digit())
-            || (self.ipv6
-                && (byte.is_ascii_hexdigit() || byte == b':' || byte == b'['))
+            || (self.ipv6 && (byte.is_ascii_hexdigit() || byte == b':' || byte == b'['))
     }
 
     fn try_at(&self, input: &[u8], pos: usize) -> Option<Range<usize>> {

--- a/squeeze/ip.rs
+++ b/squeeze/ip.rs
@@ -144,21 +144,22 @@ impl Finder for Ip {
 
     fn try_at(&self, input: &[u8], pos: usize) -> Option<Range<usize>> {
         if self.ipv6 {
-            if input[pos] == b'[' {
-                if let Some(range) = Self::try_bracketed_ipv6(input, pos) {
-                    return Some(range);
-                }
-            }
-            if input[pos].is_ascii_hexdigit() || input[pos] == b':' {
-                if let Some(range) = Self::try_bare_ipv6(input, pos) {
-                    return Some(range);
-                }
-            }
-        }
-        if self.ipv4 && input[pos].is_ascii_digit() {
-            if let Some(range) = Self::try_ipv4(input, pos) {
+            if input[pos] == b'['
+                && let Some(range) = Self::try_bracketed_ipv6(input, pos)
+            {
                 return Some(range);
             }
+            if (input[pos].is_ascii_hexdigit() || input[pos] == b':')
+                && let Some(range) = Self::try_bare_ipv6(input, pos)
+            {
+                return Some(range);
+            }
+        }
+        if self.ipv4
+            && input[pos].is_ascii_digit()
+            && let Some(range) = Self::try_ipv4(input, pos)
+        {
+            return Some(range);
         }
         None
     }
@@ -169,23 +170,24 @@ impl Finder for Ip {
 
         while idx < input.len() {
             if self.ipv6 {
-                if input[idx] == b'[' {
-                    if let Some(range) = Self::try_bracketed_ipv6(input, idx) {
-                        return Some(range);
-                    }
+                if input[idx] == b'['
+                    && let Some(range) = Self::try_bracketed_ipv6(input, idx)
+                {
+                    return Some(range);
                 }
 
-                if input[idx].is_ascii_hexdigit() || input[idx] == b':' {
-                    if let Some(range) = Self::try_bare_ipv6(input, idx) {
-                        return Some(range);
-                    }
+                if (input[idx].is_ascii_hexdigit() || input[idx] == b':')
+                    && let Some(range) = Self::try_bare_ipv6(input, idx)
+                {
+                    return Some(range);
                 }
             }
 
-            if self.ipv4 && input[idx].is_ascii_digit() {
-                if let Some(range) = Self::try_ipv4(input, idx) {
-                    return Some(range);
-                }
+            if self.ipv4
+                && input[idx].is_ascii_digit()
+                && let Some(range) = Self::try_ipv4(input, idx)
+            {
+                return Some(range);
             }
 
             idx += 1;

--- a/squeeze/ip.rs
+++ b/squeeze/ip.rs
@@ -50,8 +50,10 @@ impl Ip {
                 return None;
             }
 
-            let octet_str = std::str::from_utf8(&input[octet_start..pos]).ok()?;
-            let value: u16 = octet_str.parse().ok()?;
+            let mut value: u16 = 0;
+            for i in octet_start..pos {
+                value = value * 10 + (input[i] - b'0') as u16;
+            }
             if value > 255 {
                 return None;
             }
@@ -74,7 +76,7 @@ impl Ip {
         let close_pos = idx + close;
         let inner = &input[idx + 1..close_pos];
 
-        if Self::is_valid_ipv6(inner) {
+        if crate::ipv6::is_valid_ipv6(inner) {
             Some(idx..close_pos + 1)
         } else {
             None
@@ -118,106 +120,49 @@ impl Ip {
             return None;
         }
 
-        if Self::is_valid_ipv6(candidate) {
+        if crate::ipv6::is_valid_ipv6(candidate) {
             Some(start..end)
         } else {
             None
         }
     }
 
-    fn is_valid_ipv6(bytes: &[u8]) -> bool {
-        let s = match std::str::from_utf8(bytes) {
-            Ok(s) => s,
-            Err(_) => return false,
-        };
-
-        // Handle IPv4-mapped IPv6 (e.g., ::ffff:192.168.1.1)
-        if let Some(last_colon) = s.rfind(':') {
-            let suffix = &s[last_colon + 1..];
-            if suffix.contains('.') {
-                let prefix = &s[..last_colon + 1];
-                let prefix_bytes = prefix.as_bytes();
-                // Validate the IPv4 part
-                let parts: Vec<&str> = suffix.split('.').collect();
-                if parts.len() == 4 {
-                    let ipv4_valid = parts.iter().all(|p| {
-                        if p.is_empty() || p.len() > 3 {
-                            return false;
-                        }
-                        if p.len() > 1 && p.starts_with('0') {
-                            return false;
-                        }
-                        p.parse::<u16>().is_ok_and(|v| v <= 255)
-                    });
-                    if ipv4_valid {
-                        // Validate the prefix as IPv6 groups (should end with :)
-                        // Count the groups in prefix
-                        let trimmed = prefix.trim_end_matches(':');
-                        if trimmed.is_empty() {
-                            // Just "::" prefix — valid
-                            return prefix_bytes.windows(2).any(|w| w == b"::");
-                        }
-                        // Validate prefix groups
-                        return Self::validate_ipv6_groups(trimmed, true);
-                    }
-                }
-            }
-        }
-
-        Self::validate_ipv6_groups(s, false)
-    }
-
-    fn validate_ipv6_groups(s: &str, has_ipv4_suffix: bool) -> bool {
-        let max_groups = if has_ipv4_suffix { 6 } else { 8 };
-
-        if s == "::" {
-            return true;
-        }
-
-        let has_double_colon = s.contains("::");
-
-        // Split on :: first
-        if has_double_colon {
-            let parts: Vec<&str> = s.splitn(2, "::").collect();
-            if parts.len() != 2 {
-                return false;
-            }
-
-            let left_groups: Vec<&str> = if parts[0].is_empty() {
-                vec![]
-            } else {
-                parts[0].split(':').collect()
-            };
-
-            let right_groups: Vec<&str> = if parts[1].is_empty() {
-                vec![]
-            } else {
-                parts[1].split(':').collect()
-            };
-
-            let total = left_groups.len() + right_groups.len();
-            if total >= max_groups {
-                return false;
-            }
-
-            left_groups
-                .iter()
-                .chain(right_groups.iter())
-                .all(|g| Self::is_valid_hex_group(g))
-        } else {
-            let groups: Vec<&str> = s.split(':').collect();
-            groups.len() == max_groups && groups.iter().all(|g| Self::is_valid_hex_group(g))
-        }
-    }
-
-    fn is_valid_hex_group(g: &str) -> bool {
-        !g.is_empty() && g.len() <= 4 && g.bytes().all(|b| b.is_ascii_hexdigit())
-    }
 }
 
 impl Finder for Ip {
     fn id(&self) -> &'static str {
         "ip"
+    }
+
+    fn dispatchable(&self) -> bool {
+        true
+    }
+
+    fn could_start_at(&self, byte: u8) -> bool {
+        (self.ipv4 && byte.is_ascii_digit())
+            || (self.ipv6
+                && (byte.is_ascii_hexdigit() || byte == b':' || byte == b'['))
+    }
+
+    fn try_at(&self, input: &[u8], pos: usize) -> Option<Range<usize>> {
+        if self.ipv6 {
+            if input[pos] == b'[' {
+                if let Some(range) = Self::try_bracketed_ipv6(input, pos) {
+                    return Some(range);
+                }
+            }
+            if input[pos].is_ascii_hexdigit() || input[pos] == b':' {
+                if let Some(range) = Self::try_bare_ipv6(input, pos) {
+                    return Some(range);
+                }
+            }
+        }
+        if self.ipv4 && input[pos].is_ascii_digit() {
+            if let Some(range) = Self::try_ipv4(input, pos) {
+                return Some(range);
+            }
+        }
+        None
     }
 
     fn find(&self, s: &str) -> Option<Range<usize>> {
@@ -443,5 +388,60 @@ mod tests {
     fn find_should_handle_no_ip() {
         let finder = Ip::default();
         assert!(finder.find("just some text").is_none());
+    }
+
+    #[test]
+    fn try_at_ipv4_at_start() {
+        let finder = Ip::default();
+        let input = b"192.168.1.1 rest";
+        assert_eq!(finder.try_at(input, 0), Some(0..11));
+    }
+
+    #[test]
+    fn try_at_ipv4_mid_string() {
+        let finder = Ip::default();
+        let input = b"host 10.0.0.1 port";
+        assert_eq!(finder.try_at(input, 5), Some(5..13));
+    }
+
+    #[test]
+    fn try_at_rejects_non_digit() {
+        let finder = Ip::default();
+        let input = b"abc";
+        assert!(finder.try_at(input, 0).is_none());
+    }
+
+    #[test]
+    fn try_at_single_digit() {
+        let finder = Ip::default();
+        let input = b"1";
+        assert!(finder.try_at(input, 0).is_none());
+    }
+
+    #[test]
+    fn find_should_reject_empty_octets() {
+        let finder = Ip::default();
+        assert!(finder.find("192..1.1").is_none());
+    }
+
+    #[test]
+    fn find_should_reject_all_dots() {
+        let finder = Ip::default();
+        assert!(finder.find("...").is_none());
+    }
+
+    #[test]
+    fn try_at_bracketed_ipv6() {
+        let finder = Ip::default();
+        let input = b"[::1]";
+        assert_eq!(finder.try_at(input, 0), Some(0..5));
+    }
+
+    #[test]
+    fn find_ipv6_link_local() {
+        let finder = Ip::default();
+        let input = "addr fe80::1 here";
+        let range = finder.find(input).unwrap();
+        assert_eq!("fe80::1", &input[range]);
     }
 }

--- a/squeeze/ipv6.rs
+++ b/squeeze/ipv6.rs
@@ -9,24 +9,12 @@ pub(crate) fn is_valid_ipv6(bytes: &[u8]) -> bool {
         if suffix.contains('.') {
             let prefix = &s[..last_colon + 1];
             let prefix_bytes = prefix.as_bytes();
-            let parts: Vec<&str> = suffix.split('.').collect();
-            if parts.len() == 4 {
-                let ipv4_valid = parts.iter().all(|p| {
-                    if p.is_empty() || p.len() > 3 {
-                        return false;
-                    }
-                    if p.len() > 1 && p.starts_with('0') {
-                        return false;
-                    }
-                    p.parse::<u16>().is_ok_and(|v| v <= 255)
-                });
-                if ipv4_valid {
-                    let trimmed = prefix.trim_end_matches(':');
-                    if trimmed.is_empty() {
-                        return prefix_bytes.windows(2).any(|w| w == b"::");
-                    }
-                    return validate_groups(trimmed, true);
+            if is_valid_ipv4_suffix(suffix) {
+                let trimmed = prefix.trim_end_matches(':');
+                if trimmed.is_empty() {
+                    return prefix_bytes.windows(2).any(|w| w == b"::");
                 }
+                return validate_groups(trimmed, true);
             }
         }
     }
@@ -34,8 +22,42 @@ pub(crate) fn is_valid_ipv6(bytes: &[u8]) -> bool {
     validate_groups(s, false)
 }
 
+fn is_valid_ipv4_suffix(s: &str) -> bool {
+    let mut octet_count = 0u8;
+    let mut octet_start = 0;
+    let bytes = s.as_bytes();
+    let mut i = 0;
+
+    while i <= bytes.len() {
+        if i == bytes.len() || bytes[i] == b'.' {
+            let octet = &s[octet_start..i];
+            if octet.is_empty() || octet.len() > 3 {
+                return false;
+            }
+            if octet.len() > 1 && octet.as_bytes()[0] == b'0' {
+                return false;
+            }
+            let mut val = 0u16;
+            for &b in octet.as_bytes() {
+                if !b.is_ascii_digit() {
+                    return false;
+                }
+                val = val * 10 + (b - b'0') as u16;
+            }
+            if val > 255 {
+                return false;
+            }
+            octet_count += 1;
+            octet_start = i + 1;
+        }
+        i += 1;
+    }
+
+    octet_count == 4
+}
+
 pub(crate) fn validate_groups(s: &str, has_ipv4_suffix: bool) -> bool {
-    let max_groups = if has_ipv4_suffix { 6 } else { 8 };
+    let max_groups: usize = if has_ipv4_suffix { 6 } else { 8 };
 
     if s == "::" {
         return true;
@@ -44,37 +66,151 @@ pub(crate) fn validate_groups(s: &str, has_ipv4_suffix: bool) -> bool {
     let has_double_colon = s.contains("::");
 
     if has_double_colon {
-        let parts: Vec<&str> = s.splitn(2, "::").collect();
-        if parts.len() != 2 {
+        let Some(dc_pos) = s.find("::") else {
+            return false;
+        };
+        let left_str = &s[..dc_pos];
+        let right_str = &s[dc_pos + 2..];
+
+        let left_count = if left_str.is_empty() {
+            0
+        } else {
+            count_and_validate_groups(left_str)
+        };
+        let right_count = if right_str.is_empty() {
+            0
+        } else {
+            count_and_validate_groups(right_str)
+        };
+
+        if left_count == usize::MAX || right_count == usize::MAX {
             return false;
         }
 
-        let left: Vec<&str> = if parts[0].is_empty() {
-            vec![]
-        } else {
-            parts[0].split(':').collect()
-        };
-
-        let right: Vec<&str> = if parts[1].is_empty() {
-            vec![]
-        } else {
-            parts[1].split(':').collect()
-        };
-
-        let total = left.len() + right.len();
-        if total >= max_groups {
-            return false;
-        }
-
-        left.iter()
-            .chain(right.iter())
-            .all(|g| is_valid_hex_group(g))
+        let total = left_count + right_count;
+        total < max_groups
     } else {
-        let groups: Vec<&str> = s.split(':').collect();
-        groups.len() == max_groups && groups.iter().all(|g| is_valid_hex_group(g))
+        let count = count_and_validate_groups(s);
+        count == max_groups
     }
+}
+
+fn count_and_validate_groups(s: &str) -> usize {
+    let mut count = 0usize;
+    for g in s.split(':') {
+        if !is_valid_hex_group(g) {
+            return usize::MAX;
+        }
+        count += 1;
+    }
+    count
 }
 
 pub(crate) fn is_valid_hex_group(g: &str) -> bool {
     !g.is_empty() && g.len() <= 4 && g.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_full_ipv6() {
+        assert!(is_valid_ipv6(b"2001:0db8:85a3:0000:0000:8a2e:0370:7334"));
+    }
+
+    #[test]
+    fn valid_loopback() {
+        assert!(is_valid_ipv6(b"::1"));
+    }
+
+    #[test]
+    fn valid_all_zeros() {
+        assert!(is_valid_ipv6(b"::"));
+    }
+
+    #[test]
+    fn valid_compressed() {
+        assert!(is_valid_ipv6(b"2001:db8::1"));
+    }
+
+    #[test]
+    fn valid_leading_compressed() {
+        assert!(is_valid_ipv6(b"::ffff:192.168.1.1"));
+    }
+
+    #[test]
+    fn valid_ipv4_mapped() {
+        assert!(is_valid_ipv6(b"::ffff:127.0.0.1"));
+    }
+
+    #[test]
+    fn valid_full_eight_groups() {
+        assert!(is_valid_ipv6(b"1:2:3:4:5:6:7:8"));
+    }
+
+    #[test]
+    fn valid_with_ipv4_suffix() {
+        assert!(is_valid_ipv6(b"1:2:3:4:5:6:127.0.0.1"));
+    }
+
+    #[test]
+    fn invalid_too_many_groups() {
+        assert!(!is_valid_ipv6(b"1:2:3:4:5:6:7:8:9"));
+    }
+
+    #[test]
+    fn invalid_double_colon_twice() {
+        assert!(!is_valid_ipv6(b"1::2::3"));
+    }
+
+    #[test]
+    fn invalid_triple_colon() {
+        assert!(!is_valid_ipv6(b":::"));
+    }
+
+    #[test]
+    fn invalid_empty() {
+        assert!(!is_valid_ipv6(b""));
+    }
+
+    #[test]
+    fn invalid_group_too_long() {
+        assert!(!is_valid_ipv6(b"12345::1"));
+    }
+
+    #[test]
+    fn invalid_non_hex() {
+        assert!(!is_valid_ipv6(b"gggg::1"));
+    }
+
+    #[test]
+    fn valid_ipv4_suffix_with_compressed() {
+        assert!(is_valid_ipv6(b"::127.0.0.1"));
+    }
+
+    #[test]
+    fn invalid_ipv4_suffix_octet_over_255() {
+        assert!(!is_valid_ipv6(b"::256.0.0.1"));
+    }
+
+    #[test]
+    fn invalid_ipv4_suffix_leading_zero() {
+        assert!(!is_valid_ipv6(b"::01.0.0.1"));
+    }
+
+    #[test]
+    fn valid_fe80_link_local() {
+        assert!(is_valid_ipv6(b"fe80::1"));
+    }
+
+    #[test]
+    fn valid_only_double_colon() {
+        assert!(is_valid_ipv6(b"1::"));
+    }
+
+    #[test]
+    fn invalid_not_utf8() {
+        assert!(!is_valid_ipv6(&[0xFF, 0xFE]));
+    }
 }

--- a/squeeze/ipv6.rs
+++ b/squeeze/ipv6.rs
@@ -1,0 +1,80 @@
+pub(crate) fn is_valid_ipv6(bytes: &[u8]) -> bool {
+    let s = match std::str::from_utf8(bytes) {
+        Ok(s) => s,
+        Err(_) => return false,
+    };
+
+    if let Some(last_colon) = s.rfind(':') {
+        let suffix = &s[last_colon + 1..];
+        if suffix.contains('.') {
+            let prefix = &s[..last_colon + 1];
+            let prefix_bytes = prefix.as_bytes();
+            let parts: Vec<&str> = suffix.split('.').collect();
+            if parts.len() == 4 {
+                let ipv4_valid = parts.iter().all(|p| {
+                    if p.is_empty() || p.len() > 3 {
+                        return false;
+                    }
+                    if p.len() > 1 && p.starts_with('0') {
+                        return false;
+                    }
+                    p.parse::<u16>().is_ok_and(|v| v <= 255)
+                });
+                if ipv4_valid {
+                    let trimmed = prefix.trim_end_matches(':');
+                    if trimmed.is_empty() {
+                        return prefix_bytes.windows(2).any(|w| w == b"::");
+                    }
+                    return validate_groups(trimmed, true);
+                }
+            }
+        }
+    }
+
+    validate_groups(s, false)
+}
+
+pub(crate) fn validate_groups(s: &str, has_ipv4_suffix: bool) -> bool {
+    let max_groups = if has_ipv4_suffix { 6 } else { 8 };
+
+    if s == "::" {
+        return true;
+    }
+
+    let has_double_colon = s.contains("::");
+
+    if has_double_colon {
+        let parts: Vec<&str> = s.splitn(2, "::").collect();
+        if parts.len() != 2 {
+            return false;
+        }
+
+        let left: Vec<&str> = if parts[0].is_empty() {
+            vec![]
+        } else {
+            parts[0].split(':').collect()
+        };
+
+        let right: Vec<&str> = if parts[1].is_empty() {
+            vec![]
+        } else {
+            parts[1].split(':').collect()
+        };
+
+        let total = left.len() + right.len();
+        if total >= max_groups {
+            return false;
+        }
+
+        left.iter()
+            .chain(right.iter())
+            .all(|g| is_valid_hex_group(g))
+    } else {
+        let groups: Vec<&str> = s.split(':').collect();
+        groups.len() == max_groups && groups.iter().all(|g| is_valid_hex_group(g))
+    }
+}
+
+pub(crate) fn is_valid_hex_group(g: &str) -> bool {
+    !g.is_empty() && g.len() <= 4 && g.bytes().all(|b| b.is_ascii_hexdigit())
+}

--- a/squeeze/json.rs
+++ b/squeeze/json.rs
@@ -7,13 +7,14 @@ const MAX_DEPTH: usize = 256;
 pub struct Json {}
 
 impl Json {
-    fn try_extract(input: &[u8], start: usize) -> Option<Range<usize>> {
+    fn try_extract(input: &[u8], start: usize) -> Result<Range<usize>, usize> {
         if !matches!(input[start], b'{' | b'[') {
-            return None;
+            return Err(start + 1);
         }
 
         let mut depth: usize = 1;
         let mut pos = start + 1;
+        let mut first_inner_open: Option<usize> = None;
 
         while pos < input.len() && depth > 0 {
             match input[pos] {
@@ -33,9 +34,12 @@ impl Json {
                     continue;
                 }
                 b'{' | b'[' => {
+                    if first_inner_open.is_none() {
+                        first_inner_open = Some(pos);
+                    }
                     depth += 1;
                     if depth > MAX_DEPTH {
-                        return None;
+                        return Err(pos);
                     }
                 }
                 b'}' | b']' => {
@@ -47,9 +51,9 @@ impl Json {
         }
 
         if depth == 0 {
-            Some(start..pos)
+            Ok(start..pos)
         } else {
-            None
+            Err(first_inner_open.unwrap_or(pos))
         }
     }
 }
@@ -65,8 +69,12 @@ impl Finder for Json {
 
         while idx < input.len() {
             if input[idx] == b'{' || input[idx] == b'[' {
-                if let Some(range) = Self::try_extract(input, idx) {
-                    return Some(range);
+                match Self::try_extract(input, idx) {
+                    Ok(range) => return Some(range),
+                    Err(scanned_to) => {
+                        idx = scanned_to;
+                        continue;
+                    }
                 }
             }
             idx += 1;

--- a/squeeze/json.rs
+++ b/squeeze/json.rs
@@ -1,6 +1,9 @@
 use super::Finder;
-use memchr::memchr2;
 use std::ops::Range;
+
+fn memchr2(n1: u8, n2: u8, haystack: &[u8]) -> Option<usize> {
+    haystack.iter().position(|&b| b == n1 || b == n2)
+}
 
 const MAX_DEPTH: usize = 256;
 

--- a/squeeze/json.rs
+++ b/squeeze/json.rs
@@ -22,15 +22,21 @@ impl Json {
                 b'"' => {
                     pos += 1;
                     while pos < input.len() {
-                        if input[pos] == b'\\' {
-                            pos += 2;
-                            continue;
+                        match memchr2(b'"', b'\\', &input[pos..]) {
+                            Some(offset) => {
+                                pos += offset;
+                                if input[pos] == b'\\' {
+                                    pos += 2;
+                                } else {
+                                    pos += 1;
+                                    break;
+                                }
+                            }
+                            None => {
+                                pos = input.len();
+                                break;
+                            }
                         }
-                        if input[pos] == b'"' {
-                            pos += 1;
-                            break;
-                        }
-                        pos += 1;
                     }
                     continue;
                 }
@@ -252,5 +258,56 @@ mod tests {
         let input = r#"{unclosed and {"valid": true}"#;
         let range = finder.find(input).unwrap();
         assert_eq!(r#"{"valid": true}"#, &input[range]);
+    }
+
+    // --- Regression: memchr-accelerated string scanning ---
+
+    #[test]
+    fn find_should_handle_long_string_value() {
+        let finder = Json::default();
+        let long_val = "a".repeat(10000);
+        let input = format!(r#"{{"key": "{}"}}"#, long_val);
+        let range = finder.find(&input).unwrap();
+        assert_eq!(&input, &input[range]);
+    }
+
+    #[test]
+    fn find_should_handle_string_with_many_escapes() {
+        let finder = Json::default();
+        let escapes = r#"\\\\\\\\\\\\\\\\\\\\\"end"#;
+        let input = format!(r#"{{"key": "{}"}}"#, escapes);
+        let range = finder.find(&input).unwrap();
+        assert_eq!(&input, &input[range]);
+    }
+
+    #[test]
+    fn find_should_handle_string_with_braces_inside() {
+        let finder = Json::default();
+        let input = r#"{"template": "{{not nested}}"}"#;
+        let range = finder.find(input).unwrap();
+        assert_eq!(input, &input[range]);
+    }
+
+    #[test]
+    fn find_should_handle_unclosed_string_in_object() {
+        let finder = Json::default();
+        let input = r#"{"key": "unterminated"#;
+        assert!(finder.find(input).is_none());
+    }
+
+    #[test]
+    fn find_should_handle_empty_strings() {
+        let finder = Json::default();
+        let input = r#"{"": ""}"#;
+        let range = finder.find(input).unwrap();
+        assert_eq!(r#"{"": ""}"#, &input[range]);
+    }
+
+    #[test]
+    fn find_should_handle_escape_at_string_end() {
+        let finder = Json::default();
+        let input = r#"{"key": "val\\"}"#;
+        let range = finder.find(input).unwrap();
+        assert_eq!(input, &input[range]);
     }
 }

--- a/squeeze/json.rs
+++ b/squeeze/json.rs
@@ -1,4 +1,5 @@
 use super::Finder;
+use memchr::memchr2;
 use std::ops::Range;
 
 const MAX_DEPTH: usize = 256;
@@ -67,17 +68,14 @@ impl Finder for Json {
         let input = s.as_bytes();
         let mut idx = 0;
 
-        while idx < input.len() {
-            if input[idx] == b'{' || input[idx] == b'[' {
-                match Self::try_extract(input, idx) {
-                    Ok(range) => return Some(range),
-                    Err(scanned_to) => {
-                        idx = scanned_to;
-                        continue;
-                    }
+        while let Some(offset) = memchr2(b'{', b'[', &input[idx..]) {
+            idx += offset;
+            match Self::try_extract(input, idx) {
+                Ok(range) => return Some(range),
+                Err(scanned_to) => {
+                    idx = scanned_to.min(input.len());
                 }
             }
-            idx += 1;
         }
 
         None

--- a/squeeze/jwt.rs
+++ b/squeeze/jwt.rs
@@ -58,30 +58,19 @@ impl Finder for Jwt {
         if pos > 0 && Self::is_base64url(input[pos - 1]) {
             return None;
         }
-        let header_end = match Self::read_segment(input, pos) {
-            Some(end) => end,
-            None => return None,
-        };
+        let header_end = Self::read_segment(input, pos)?;
         if !Self::looks_like_jwt_header(input, pos, header_end) {
             return None;
         }
         if header_end >= input.len() || input[header_end] != b'.' {
             return None;
         }
-        let payload_end = match Self::read_segment(input, header_end + 1) {
-            Some(end) => end,
-            None => return None,
-        };
+        let payload_end = Self::read_segment(input, header_end + 1)?;
         if payload_end >= input.len() || input[payload_end] != b'.' {
             return None;
         }
-        let sig_end = match Self::read_segment(input, payload_end + 1) {
-            Some(end) => end,
-            None => return None,
-        };
-        if sig_end < input.len()
-            && (Self::is_base64url(input[sig_end]) || input[sig_end] == b'.')
-        {
+        let sig_end = Self::read_segment(input, payload_end + 1)?;
+        if sig_end < input.len() && (Self::is_base64url(input[sig_end]) || input[sig_end] == b'.') {
             return None;
         }
         Some(pos..sig_end)

--- a/squeeze/jwt.rs
+++ b/squeeze/jwt.rs
@@ -199,9 +199,11 @@ mod tests {
     #[test]
     fn find_should_reject_two_segments() {
         let finder = Jwt::default();
-        assert!(finder
-            .find("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0")
-            .is_none());
+        assert!(
+            finder
+                .find("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0")
+                .is_none()
+        );
     }
 
     #[test]

--- a/squeeze/jwt.rs
+++ b/squeeze/jwt.rs
@@ -43,6 +43,50 @@ impl Finder for Jwt {
         "jwt"
     }
 
+    fn dispatchable(&self) -> bool {
+        true
+    }
+
+    fn could_start_at(&self, byte: u8) -> bool {
+        byte == b'e'
+    }
+
+    fn try_at(&self, input: &[u8], pos: usize) -> Option<Range<usize>> {
+        if input[pos] != b'e' {
+            return None;
+        }
+        if pos > 0 && Self::is_base64url(input[pos - 1]) {
+            return None;
+        }
+        let header_end = match Self::read_segment(input, pos) {
+            Some(end) => end,
+            None => return None,
+        };
+        if !Self::looks_like_jwt_header(input, pos, header_end) {
+            return None;
+        }
+        if header_end >= input.len() || input[header_end] != b'.' {
+            return None;
+        }
+        let payload_end = match Self::read_segment(input, header_end + 1) {
+            Some(end) => end,
+            None => return None,
+        };
+        if payload_end >= input.len() || input[payload_end] != b'.' {
+            return None;
+        }
+        let sig_end = match Self::read_segment(input, payload_end + 1) {
+            Some(end) => end,
+            None => return None,
+        };
+        if sig_end < input.len()
+            && (Self::is_base64url(input[sig_end]) || input[sig_end] == b'.')
+        {
+            return None;
+        }
+        Some(pos..sig_end)
+    }
+
     fn find(&self, s: &str) -> Option<Range<usize>> {
         let input = s.as_bytes();
         let mut idx = 0;
@@ -213,5 +257,55 @@ mod tests {
     fn find_should_reject_short_segments() {
         let finder = Jwt::default();
         assert!(finder.find("eyJ.ab.cd").is_none());
+    }
+
+    #[test]
+    fn try_at_valid_jwt() {
+        let finder = Jwt::default();
+        let input = JWT_HS256.as_bytes();
+        assert_eq!(finder.try_at(input, 0), Some(0..input.len()));
+    }
+
+    #[test]
+    fn try_at_preceded_by_base64() {
+        let finder = Jwt::default();
+        let input = format!("x{}", JWT_HS256);
+        assert!(finder.try_at(input.as_bytes(), 1).is_none());
+    }
+
+    #[test]
+    fn try_at_non_e() {
+        let finder = Jwt::default();
+        assert!(finder.try_at(b"abc", 0).is_none());
+    }
+
+    #[test]
+    fn try_at_single_e() {
+        let finder = Jwt::default();
+        assert!(finder.try_at(b"e", 0).is_none());
+    }
+
+    #[test]
+    fn try_at_eyj_only() {
+        let finder = Jwt::default();
+        assert!(finder.try_at(b"eyJ", 0).is_none());
+    }
+
+    #[test]
+    fn find_four_segments_finds_inner_jwt() {
+        let finder = Jwt::default();
+        let input = format!("{}.extra", JWT_HS256);
+        let range = finder.find(&input).unwrap();
+        let found = &input[range];
+        assert!(found.starts_with("eyJzdWIi"));
+        assert!(found.ends_with("extra"));
+    }
+
+    #[test]
+    fn find_should_extract_jwt_after_space() {
+        let finder = Jwt::default();
+        let input = format!(" {}", JWT_HS256);
+        let range = finder.find(&input).unwrap();
+        assert_eq!(JWT_HS256, &input[range]);
     }
 }

--- a/squeeze/lib.rs
+++ b/squeeze/lib.rs
@@ -9,6 +9,7 @@
 //! - [`color::Color`] - Extract colors (hex, rgb, hsl)
 //! - [`datetime::Datetime`] - Extract ISO 8601 datetimes
 //! - [`email::Email`] - Extract email addresses
+//! - [`emoji::Emoji`] - Extract emojis and emoji sequences
 //! - [`env::Env`] - Extract environment variable references
 //! - [`hash::Hash`] - Extract hashes (MD5, SHA-1, SHA-256, SHA-512)
 //! - [`ip::Ip`] - Extract IP addresses (IPv4, IPv6)
@@ -34,11 +35,13 @@
 //! }
 //! ```
 
+pub(crate) mod ipv6;
 pub mod cidr;
 pub mod codetag;
 pub mod color;
 pub mod datetime;
 pub mod email;
+pub mod emoji;
 pub mod env;
 pub mod hash;
 pub mod ip;
@@ -48,6 +51,7 @@ pub mod mac;
 pub mod mirror;
 pub mod path;
 pub mod phone;
+pub mod scanner;
 pub mod semver;
 pub mod uri;
 pub mod uuid;
@@ -83,8 +87,6 @@ use std::ops::Range;
 /// ```
 pub trait Finder {
     /// Returns a unique identifier for this finder.
-    ///
-    /// This is used for logging and debugging purposes.
     fn id(&self) -> &'static str;
 
     /// Finds the first match in the given string.
@@ -92,4 +94,21 @@ pub trait Finder {
     /// Returns `Some(range)` containing the byte range of the match, or `None` if no match is found.
     /// The range is relative to the input string slice.
     fn find(&self, s: &str) -> Option<Range<usize>>;
+
+    /// Whether this finder supports dispatch-mode scanning via [`try_at`](Finder::try_at).
+    fn dispatchable(&self) -> bool {
+        false
+    }
+
+    /// Whether the given byte could be the first byte of a match.
+    /// Only meaningful when [`dispatchable`](Finder::dispatchable) returns true.
+    fn could_start_at(&self, _byte: u8) -> bool {
+        true
+    }
+
+    /// Try to find a match starting exactly at `pos` in the full input.
+    /// Only called when [`dispatchable`](Finder::dispatchable) returns true.
+    fn try_at(&self, _input: &[u8], _pos: usize) -> Option<Range<usize>> {
+        None
+    }
 }

--- a/squeeze/lib.rs
+++ b/squeeze/lib.rs
@@ -35,7 +35,6 @@
 //! }
 //! ```
 
-pub(crate) mod ipv6;
 pub mod cidr;
 pub mod codetag;
 pub mod color;
@@ -45,6 +44,7 @@ pub mod emoji;
 pub mod env;
 pub mod hash;
 pub mod ip;
+pub(crate) mod ipv6;
 pub mod json;
 pub mod jwt;
 pub mod mac;

--- a/squeeze/mac.rs
+++ b/squeeze/mac.rs
@@ -78,6 +78,31 @@ impl Finder for Mac {
         "mac"
     }
 
+    fn dispatchable(&self) -> bool {
+        true
+    }
+
+    fn could_start_at(&self, byte: u8) -> bool {
+        byte.is_ascii_hexdigit()
+    }
+
+    fn try_at(&self, input: &[u8], pos: usize) -> Option<Range<usize>> {
+        if !Self::is_hex(input[pos]) {
+            return None;
+        }
+        if pos > 0
+            && (Self::is_hex(input[pos - 1])
+                || input[pos - 1] == b':'
+                || input[pos - 1] == b'-'
+                || input[pos - 1] == b'.')
+        {
+            return None;
+        }
+        Self::try_mac_colon(input, pos)
+            .or_else(|| Self::try_mac_dash(input, pos))
+            .or_else(|| Self::try_mac_dot(input, pos))
+    }
+
     fn find(&self, s: &str) -> Option<Range<usize>> {
         let input = s.as_bytes();
         let mut idx = 0;
@@ -247,5 +272,62 @@ mod tests {
         let input = "00:00:00:00:00:00";
         let range = finder.find(input).unwrap();
         assert_eq!("00:00:00:00:00:00", &input[range]);
+    }
+
+    #[test]
+    fn try_at_colon_mac() {
+        let finder = Mac::default();
+        let input = b"00:1A:2B:3C:4D:5E rest";
+        assert_eq!(finder.try_at(input, 0), Some(0..17));
+    }
+
+    #[test]
+    fn try_at_dash_mac() {
+        let finder = Mac::default();
+        let input = b"00-1A-2B-3C-4D-5E rest";
+        assert_eq!(finder.try_at(input, 0), Some(0..17));
+    }
+
+    #[test]
+    fn try_at_dot_mac() {
+        let finder = Mac::default();
+        let input = b"001A.2B3C.4D5E rest";
+        assert_eq!(finder.try_at(input, 0), Some(0..14));
+    }
+
+    #[test]
+    fn try_at_preceded_by_hex() {
+        let finder = Mac::default();
+        let input = b"ff00:1A:2B:3C:4D:5E";
+        assert!(finder.try_at(input, 2).is_none());
+    }
+
+    #[test]
+    fn try_at_preceded_by_colon() {
+        let finder = Mac::default();
+        let input = b":00:1A:2B:3C:4D:5E";
+        assert!(finder.try_at(input, 1).is_none());
+    }
+
+    #[test]
+    fn try_at_short_input() {
+        let finder = Mac::default();
+        let input = b"00:1A";
+        assert!(finder.try_at(input, 0).is_none());
+    }
+
+    #[test]
+    fn try_at_non_hex() {
+        let finder = Mac::default();
+        let input = b"zz";
+        assert!(finder.try_at(input, 0).is_none());
+    }
+
+    #[test]
+    fn find_should_extract_mac_at_end() {
+        let finder = Mac::default();
+        let input = "addr 00:1A:2B:3C:4D:5E";
+        let range = finder.find(input).unwrap();
+        assert_eq!("00:1A:2B:3C:4D:5E", &input[range]);
     }
 }

--- a/squeeze/path.rs
+++ b/squeeze/path.rs
@@ -78,10 +78,7 @@ impl Finder for Path {
                 }
                 2
             }
-            b'.' if pos + 2 < input.len()
-                && input[pos + 1] == b'.'
-                && input[pos + 2] == b'/' =>
-            {
+            b'.' if pos + 2 < input.len() && input[pos + 1] == b'.' && input[pos + 2] == b'/' => {
                 if pos > 0 && !Self::is_boundary(input[pos - 1]) {
                     return None;
                 }

--- a/squeeze/path.rs
+++ b/squeeze/path.rs
@@ -62,6 +62,79 @@ impl Finder for Path {
         "path"
     }
 
+    fn dispatchable(&self) -> bool {
+        true
+    }
+
+    fn could_start_at(&self, byte: u8) -> bool {
+        matches!(byte, b'/' | b'.' | b'~')
+    }
+
+    fn try_at(&self, input: &[u8], pos: usize) -> Option<Range<usize>> {
+        let prefix_len = match input[pos] {
+            b'~' if pos + 1 < input.len() && input[pos + 1] == b'/' => {
+                if pos > 0 && !Self::is_boundary(input[pos - 1]) {
+                    return None;
+                }
+                2
+            }
+            b'.' if pos + 2 < input.len()
+                && input[pos + 1] == b'.'
+                && input[pos + 2] == b'/' =>
+            {
+                if pos > 0 && !Self::is_boundary(input[pos - 1]) {
+                    return None;
+                }
+                3
+            }
+            b'.' if pos + 1 < input.len() && input[pos + 1] == b'/' => {
+                if pos > 0 && !Self::is_boundary(input[pos - 1]) {
+                    return None;
+                }
+                2
+            }
+            b'/' => {
+                if pos > 0 && input[pos - 1] == b':' {
+                    return None;
+                }
+                if pos > 0 && !Self::is_boundary(input[pos - 1]) {
+                    return None;
+                }
+                if pos + 1 >= input.len() || input[pos + 1].is_ascii_whitespace() {
+                    return None;
+                }
+                1
+            }
+            _ => return None,
+        };
+
+        let start = pos;
+        let mut end = pos + prefix_len;
+        while end < input.len() && !input[end].is_ascii_whitespace() {
+            end += 1;
+        }
+        while end > start + prefix_len
+            && matches!(
+                input[end - 1],
+                b',' | b';' | b')' | b']' | b'}' | b'>' | b'\'' | b'"' | b'`'
+            )
+        {
+            end -= 1;
+        }
+        while end > start + prefix_len && input[end - 1] == b':' {
+            end -= 1;
+        }
+        while end > start + prefix_len && input[end - 1] == b'.' {
+            end -= 1;
+        }
+
+        if end > start + prefix_len {
+            Some(start..end)
+        } else {
+            None
+        }
+    }
+
     fn find(&self, s: &str) -> Option<Range<usize>> {
         let input = s.as_bytes();
         let mut search_from = 0;
@@ -329,5 +402,85 @@ mod tests {
     fn find_should_not_match_slash_space() {
         let finder = Path::default();
         assert!(finder.find("/ foo").is_none());
+    }
+
+    #[test]
+    fn try_at_absolute_path() {
+        let finder = Path::default();
+        let input = b"/etc/hosts rest";
+        assert_eq!(finder.try_at(input, 0), Some(0..10));
+    }
+
+    #[test]
+    fn try_at_relative_path() {
+        let finder = Path::default();
+        let input = b"./src/main.rs rest";
+        assert_eq!(finder.try_at(input, 0), Some(0..13));
+    }
+
+    #[test]
+    fn try_at_parent_path() {
+        let finder = Path::default();
+        let input = b"../README.md rest";
+        assert_eq!(finder.try_at(input, 0), Some(0..12));
+    }
+
+    #[test]
+    fn try_at_home_path() {
+        let finder = Path::default();
+        let input = b"~/.bashrc rest";
+        assert_eq!(finder.try_at(input, 0), Some(0..9));
+    }
+
+    #[test]
+    fn try_at_rejects_mid_word() {
+        let finder = Path::default();
+        let input = b"and/or";
+        assert!(finder.try_at(input, 3).is_none());
+    }
+
+    #[test]
+    fn try_at_slash_at_end() {
+        let finder = Path::default();
+        let input = b"/";
+        assert!(finder.try_at(input, 0).is_none());
+    }
+
+    #[test]
+    fn try_at_tilde_no_slash() {
+        let finder = Path::default();
+        let input = b"~x";
+        assert!(finder.try_at(input, 0).is_none());
+    }
+
+    #[test]
+    fn try_at_dot_no_slash() {
+        let finder = Path::default();
+        let input = b".x";
+        assert!(finder.try_at(input, 0).is_none());
+    }
+
+    #[test]
+    fn find_strips_trailing_multiple_periods() {
+        let finder = Path::default();
+        let input = "/etc/hosts...";
+        let range = finder.find(input).unwrap();
+        assert_eq!("/etc/hosts", &input[range]);
+    }
+
+    #[test]
+    fn find_preserves_internal_dots() {
+        let finder = Path::default();
+        let input = "/path/to/file.tar.gz more";
+        let range = finder.find(input).unwrap();
+        assert_eq!("/path/to/file.tar.gz", &input[range]);
+    }
+
+    #[test]
+    fn find_strips_trailing_colons() {
+        let finder = Path::default();
+        let input = "/etc/hosts: error";
+        let range = finder.find(input).unwrap();
+        assert_eq!("/etc/hosts", &input[range]);
     }
 }

--- a/squeeze/scanner.rs
+++ b/squeeze/scanner.rs
@@ -1,0 +1,790 @@
+use crate::Finder;
+use std::ops::Range;
+
+const CL_DIGIT: u16 = 1 << 0;
+const CL_HEX_ALPHA: u16 = 1 << 1;
+const CL_ALPHA_OTHER: u16 = 1 << 2;
+const CL_AT: u16 = 1 << 3;
+const CL_DOLLAR: u16 = 1 << 4;
+const CL_HASH: u16 = 1 << 5;
+const CL_OPEN_BRACE: u16 = 1 << 6;
+const CL_OPEN_BRACKET: u16 = 1 << 7;
+const CL_COLON: u16 = 1 << 8;
+const CL_DOT: u16 = 1 << 9;
+const CL_SLASH: u16 = 1 << 10;
+const CL_TILDE: u16 = 1 << 11;
+const CL_PLUS: u16 = 1 << 12;
+const CL_OPEN_PAREN: u16 = 1 << 13;
+const CL_DASH: u16 = 1 << 14;
+
+const CL_HEX: u16 = CL_DIGIT | CL_HEX_ALPHA;
+
+const fn build_byte_class_table() -> [u16; 256] {
+    let mut table = [0u16; 256];
+    let mut i = 0u16;
+    while i < 256 {
+        let b = i as u8;
+        let mut c = 0u16;
+        if b >= b'0' && b <= b'9' {
+            c |= CL_DIGIT;
+        }
+        if (b >= b'a' && b <= b'f') || (b >= b'A' && b <= b'F') {
+            c |= CL_HEX_ALPHA;
+        }
+        if (b >= b'g' && b <= b'z') || (b >= b'G' && b <= b'Z') {
+            c |= CL_ALPHA_OTHER;
+        }
+        if b == b'@' {
+            c |= CL_AT;
+        }
+        if b == b'$' {
+            c |= CL_DOLLAR;
+        }
+        if b == b'#' {
+            c |= CL_HASH;
+        }
+        if b == b'{' {
+            c |= CL_OPEN_BRACE;
+        }
+        if b == b'[' {
+            c |= CL_OPEN_BRACKET;
+        }
+        if b == b':' {
+            c |= CL_COLON;
+        }
+        if b == b'.' {
+            c |= CL_DOT;
+        }
+        if b == b'/' {
+            c |= CL_SLASH;
+        }
+        if b == b'~' {
+            c |= CL_TILDE;
+        }
+        if b == b'+' {
+            c |= CL_PLUS;
+        }
+        if b == b'(' {
+            c |= CL_OPEN_PAREN;
+        }
+        if b == b'-' {
+            c |= CL_DASH;
+        }
+        table[i as usize] = c;
+        i += 1;
+    }
+    table
+}
+
+static BYTE_CLASSES: [u16; 256] = build_byte_class_table();
+
+fn prescan(input: &[u8]) -> u16 {
+    let mut classes = 0u16;
+    for &b in input {
+        classes |= BYTE_CLASSES[b as usize];
+    }
+    classes
+}
+
+fn can_skip_finder(id: &str, cl: u16) -> bool {
+    match id {
+        "cidr" => (cl & CL_DIGIT) == 0 || (cl & CL_SLASH) == 0,
+        "codetag" => (cl & CL_COLON) == 0,
+        "color" => (cl & CL_HASH) == 0 && (cl & (CL_ALPHA_OTHER | CL_HEX_ALPHA)) == 0,
+        "datetime" => (cl & CL_DIGIT) == 0,
+        "email" => (cl & CL_AT) == 0,
+        "emoji" => false,
+        "env" => (cl & CL_DOLLAR) == 0,
+        "hash" => (cl & CL_HEX) == 0,
+        "ip" => (cl & (CL_DIGIT | CL_HEX_ALPHA | CL_COLON | CL_OPEN_BRACKET)) == 0,
+        "json" => (cl & (CL_OPEN_BRACE | CL_OPEN_BRACKET)) == 0,
+        "jwt" => (cl & CL_HEX_ALPHA) == 0,
+        "mac" => {
+            (cl & CL_HEX) == 0
+                || ((cl & CL_COLON) == 0 && (cl & CL_DASH) == 0 && (cl & CL_DOT) == 0)
+        }
+        "mirror" => false,
+        "path" => (cl & (CL_SLASH | CL_DOT | CL_TILDE)) == 0,
+        "phone" => (cl & (CL_DIGIT | CL_PLUS | CL_OPEN_PAREN)) == 0,
+        "semver" => (cl & CL_DIGIT) == 0 || (cl & CL_DOT) == 0,
+        "uri" => (cl & CL_COLON) == 0,
+        "uuid" => (cl & CL_HEX) == 0 || (cl & CL_DASH) == 0,
+        _ => false,
+    }
+}
+
+pub struct Match {
+    pub finder_index: usize,
+    pub range: Range<usize>,
+}
+
+pub struct Scanner {
+    finders: Vec<Box<dyn Finder>>,
+    dispatch: [u32; 256],
+    dispatch_mask: u32,
+    scan_mask: u32,
+}
+
+impl Scanner {
+    pub fn new(finders: Vec<Box<dyn Finder>>) -> Self {
+        assert!(finders.len() <= 32);
+
+        let mut dispatch = [0u32; 256];
+        let mut dispatch_mask = 0u32;
+        let mut scan_mask = 0u32;
+
+        for (i, finder) in finders.iter().enumerate() {
+            let bit = 1u32 << i;
+            if finder.dispatchable() {
+                dispatch_mask |= bit;
+                for b in 0..=255u8 {
+                    if finder.could_start_at(b) {
+                        dispatch[b as usize] |= bit;
+                    }
+                }
+            } else {
+                scan_mask |= bit;
+            }
+        }
+
+        Scanner {
+            finders,
+            dispatch,
+            dispatch_mask,
+            scan_mask,
+        }
+    }
+
+    pub fn finders(&self) -> &[Box<dyn Finder>] {
+        &self.finders
+    }
+
+    pub fn scan_line(&self, line: &str) -> Vec<Match> {
+        let input = line.as_bytes();
+        if input.is_empty() {
+            return Vec::new();
+        }
+
+        let line_classes = prescan(input);
+
+        let mut active = 0u32;
+        for (i, finder) in self.finders.iter().enumerate() {
+            if !can_skip_finder(finder.id(), line_classes) {
+                active |= 1u32 << i;
+            }
+        }
+        if active == 0 {
+            return Vec::new();
+        }
+
+        let mut matches = Vec::new();
+
+        let active_scan = active & self.scan_mask;
+        if active_scan != 0 {
+            for i in 0..self.finders.len() {
+                if (active_scan & (1u32 << i)) == 0 {
+                    continue;
+                }
+                let finder = &self.finders[i];
+                let mut idx = 0;
+                while idx < line.len() {
+                    if let Some(range) = finder.find(&line[idx..]) {
+                        matches.push(Match {
+                            finder_index: i,
+                            range: (idx + range.start)..(idx + range.end),
+                        });
+                        idx += range.end;
+                    } else {
+                        break;
+                    }
+                }
+            }
+        }
+
+        let active_dispatch = active & self.dispatch_mask;
+        if active_dispatch != 0 {
+            let mut finder_pos = vec![0usize; self.finders.len()];
+
+            for pos in 0..input.len() {
+                let mut candidates = self.dispatch[input[pos] as usize] & active_dispatch;
+                while candidates != 0 {
+                    let i = candidates.trailing_zeros() as usize;
+                    candidates &= candidates - 1;
+
+                    if pos < finder_pos[i] {
+                        continue;
+                    }
+                    if let Some(range) = self.finders[i].try_at(input, pos) {
+                        matches.push(Match {
+                            finder_index: i,
+                            range: range.clone(),
+                        });
+                        finder_pos[i] = range.end;
+                    }
+                }
+            }
+        }
+
+        matches.sort_by(|a, b| {
+            a.range
+                .start
+                .cmp(&b.range.start)
+                .then(a.finder_index.cmp(&b.finder_index))
+        });
+
+        matches
+    }
+
+    pub fn scan_line_first(&self, line: &str) -> Option<Match> {
+        let input = line.as_bytes();
+        if input.is_empty() {
+            return None;
+        }
+
+        let line_classes = prescan(input);
+
+        let mut active = 0u32;
+        for (i, finder) in self.finders.iter().enumerate() {
+            if !can_skip_finder(finder.id(), line_classes) {
+                active |= 1u32 << i;
+            }
+        }
+        if active == 0 {
+            return None;
+        }
+
+        let mut best: Option<Match> = None;
+
+        for (i, finder) in self.finders.iter().enumerate() {
+            if (active & (1u32 << i)) == 0 {
+                continue;
+            }
+            if let Some(range) = finder.find(line) {
+                let is_better = match &best {
+                    None => true,
+                    Some(b) => range.start < b.range.start,
+                };
+                if is_better {
+                    best = Some(Match {
+                        finder_index: i,
+                        range,
+                    });
+                }
+            }
+        }
+
+        best
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prescan_empty_input() {
+        assert_eq!(prescan(b""), 0);
+    }
+
+    #[test]
+    fn prescan_detects_digit() {
+        assert_ne!(prescan(b"abc123") & CL_DIGIT, 0);
+    }
+
+    #[test]
+    fn prescan_detects_at() {
+        assert_ne!(prescan(b"user@host") & CL_AT, 0);
+    }
+
+    #[test]
+    fn prescan_detects_dollar() {
+        assert_ne!(prescan(b"$HOME") & CL_DOLLAR, 0);
+    }
+
+    #[test]
+    fn prescan_no_false_positives() {
+        let cl = prescan(b"hello world");
+        assert_eq!(cl & CL_AT, 0);
+        assert_eq!(cl & CL_DOLLAR, 0);
+        assert_eq!(cl & CL_DIGIT, 0);
+    }
+
+    #[test]
+    fn can_skip_email_without_at() {
+        let cl = prescan(b"hello world");
+        assert!(can_skip_finder("email", cl));
+    }
+
+    #[test]
+    fn cannot_skip_email_with_at() {
+        let cl = prescan(b"user@example.com");
+        assert!(!can_skip_finder("email", cl));
+    }
+
+    #[test]
+    fn can_skip_env_without_dollar() {
+        let cl = prescan(b"no vars here");
+        assert!(can_skip_finder("env", cl));
+    }
+
+    #[test]
+    fn can_skip_json_without_brackets() {
+        let cl = prescan(b"no json here");
+        assert!(can_skip_finder("json", cl));
+    }
+
+    #[test]
+    fn can_skip_uri_without_colon() {
+        let cl = prescan(b"no uris here");
+        assert!(can_skip_finder("uri", cl));
+    }
+
+    #[test]
+    fn can_skip_uuid_without_dash() {
+        let cl = prescan(b"abcdef1234567890");
+        assert!(can_skip_finder("uuid", cl));
+    }
+
+    #[test]
+    fn cannot_skip_mirror() {
+        let cl = prescan(b"anything");
+        assert!(!can_skip_finder("mirror", cl));
+    }
+
+    #[test]
+    fn can_skip_hash_without_hex() {
+        let cl = prescan(b"no hx zzz");
+        assert!(can_skip_finder("hash", cl));
+    }
+
+    #[test]
+    fn can_skip_mac_without_separator() {
+        let cl = prescan(b"aabbccddeeff");
+        assert!(can_skip_finder("mac", cl));
+    }
+
+    #[test]
+    fn can_skip_semver_without_dot() {
+        let cl = prescan(b"version 100");
+        assert!(can_skip_finder("semver", cl));
+    }
+
+    #[test]
+    fn can_skip_cidr_without_slash() {
+        let cl = prescan(b"192.168.1.0");
+        assert!(can_skip_finder("cidr", cl));
+    }
+
+    #[test]
+    fn can_skip_path_without_prefix() {
+        let cl = prescan(b"no paths here");
+        assert!(can_skip_finder("path", cl));
+    }
+
+    #[test]
+    fn scanner_empty_finders() {
+        let scanner = Scanner::new(Vec::new());
+        assert!(scanner.scan_line("hello").is_empty());
+    }
+
+    #[test]
+    fn scanner_empty_line() {
+        let finders: Vec<Box<dyn Finder>> =
+            vec![Box::new(crate::mirror::Mirror::default())];
+        let scanner = Scanner::new(finders);
+        assert!(scanner.scan_line("").is_empty());
+    }
+
+    #[test]
+    fn scanner_mirror_matches_everything() {
+        let finders: Vec<Box<dyn Finder>> =
+            vec![Box::new(crate::mirror::Mirror::default())];
+        let scanner = Scanner::new(finders);
+        let matches = scanner.scan_line("hello world");
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].range, 0..11);
+    }
+
+    #[test]
+    fn scanner_prescan_skips_impossible_finders() {
+        let finders: Vec<Box<dyn Finder>> =
+            vec![Box::new(crate::email::Email::default())];
+        let scanner = Scanner::new(finders);
+        let matches = scanner.scan_line("no at sign here");
+        assert!(matches.is_empty());
+    }
+
+    #[test]
+    fn scanner_dispatch_finds_hash() {
+        let finders: Vec<Box<dyn Finder>> =
+            vec![Box::new(crate::hash::Hash::default())];
+        let scanner = Scanner::new(finders);
+        let input = "md5: 5d41402abc4b2a76b9719d911017c592";
+        let matches = scanner.scan_line(input);
+        assert_eq!(matches.len(), 1);
+        assert_eq!(
+            &input[matches[0].range.clone()],
+            "5d41402abc4b2a76b9719d911017c592"
+        );
+    }
+
+    #[test]
+    fn scanner_dispatch_finds_multiple_hashes() {
+        let finders: Vec<Box<dyn Finder>> =
+            vec![Box::new(crate::hash::Hash::default())];
+        let scanner = Scanner::new(finders);
+        let input = "5d41402abc4b2a76b9719d911017c592 and 2aae6c35c94fcfb415dbe95f408b9ce91ee846ed";
+        let matches = scanner.scan_line(input);
+        assert_eq!(matches.len(), 2);
+        assert_eq!(
+            &input[matches[0].range.clone()],
+            "5d41402abc4b2a76b9719d911017c592"
+        );
+        assert_eq!(
+            &input[matches[1].range.clone()],
+            "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed"
+        );
+    }
+
+    #[test]
+    fn scanner_mixed_dispatch_and_scan() {
+        let finders: Vec<Box<dyn Finder>> = vec![
+            Box::new(crate::hash::Hash::default()),
+            Box::new(crate::email::Email::default()),
+        ];
+        let scanner = Scanner::new(finders);
+        let input = "user@example.com 5d41402abc4b2a76b9719d911017c592";
+        let matches = scanner.scan_line(input);
+        assert_eq!(matches.len(), 2);
+        assert_eq!(&input[matches[0].range.clone()], "user@example.com");
+        assert_eq!(
+            &input[matches[1].range.clone()],
+            "5d41402abc4b2a76b9719d911017c592"
+        );
+    }
+
+    #[test]
+    fn scanner_position_ordered_output() {
+        let finders: Vec<Box<dyn Finder>> = vec![
+            Box::new(crate::env::Env::default()),
+            Box::new(crate::hash::Hash::default()),
+        ];
+        let scanner = Scanner::new(finders);
+        let input = "5d41402abc4b2a76b9719d911017c592 $HOME";
+        let matches = scanner.scan_line(input);
+        assert_eq!(matches.len(), 2);
+        assert!(matches[0].range.start < matches[1].range.start);
+    }
+
+    #[test]
+    fn scanner_first_returns_earliest() {
+        let finders: Vec<Box<dyn Finder>> = vec![
+            Box::new(crate::env::Env::default()),
+            Box::new(crate::hash::Hash::default()),
+        ];
+        let scanner = Scanner::new(finders);
+        let input = "$HOME then 5d41402abc4b2a76b9719d911017c592";
+        let m = scanner.scan_line_first(input).unwrap();
+        assert_eq!(&input[m.range], "$HOME");
+    }
+
+    #[test]
+    fn scanner_dispatch_finds_env() {
+        let finders: Vec<Box<dyn Finder>> =
+            vec![Box::new(crate::env::Env::default())];
+        let scanner = Scanner::new(finders);
+        let input = "use $HOME and ${PATH}";
+        let matches = scanner.scan_line(input);
+        assert_eq!(matches.len(), 2);
+        assert_eq!(&input[matches[0].range.clone()], "$HOME");
+        assert_eq!(&input[matches[1].range.clone()], "${PATH}");
+    }
+
+    #[test]
+    fn scanner_dispatch_finds_json() {
+        let finders: Vec<Box<dyn Finder>> =
+            vec![Box::new(crate::json::Json::default())];
+        let scanner = Scanner::new(finders);
+        let input = r#"data: {"key": "value"} end"#;
+        let matches = scanner.scan_line(input);
+        assert_eq!(matches.len(), 1);
+        assert_eq!(&input[matches[0].range.clone()], r#"{"key": "value"}"#);
+    }
+
+    #[test]
+    fn scanner_dispatch_finds_uuid() {
+        let finders: Vec<Box<dyn Finder>> =
+            vec![Box::new(crate::uuid::Uuid::default())];
+        let scanner = Scanner::new(finders);
+        let input = "id: 550e8400-e29b-41d4-a716-446655440000 end";
+        let matches = scanner.scan_line(input);
+        assert_eq!(matches.len(), 1);
+        assert_eq!(
+            &input[matches[0].range.clone()],
+            "550e8400-e29b-41d4-a716-446655440000"
+        );
+    }
+
+    #[test]
+    fn scanner_dispatch_finds_color() {
+        let finders: Vec<Box<dyn Finder>> =
+            vec![Box::new(crate::color::Color::default())];
+        let scanner = Scanner::new(finders);
+        let input = "color: #ff00aa and rgb(0, 255, 0)";
+        let matches = scanner.scan_line(input);
+        assert_eq!(matches.len(), 2);
+        assert_eq!(&input[matches[0].range.clone()], "#ff00aa");
+        assert_eq!(&input[matches[1].range.clone()], "rgb(0, 255, 0)");
+    }
+
+    #[test]
+    fn scanner_dispatch_finds_ip() {
+        let finders: Vec<Box<dyn Finder>> =
+            vec![Box::new(crate::ip::Ip::default())];
+        let scanner = Scanner::new(finders);
+        let input = "connect to 192.168.1.1 now";
+        let matches = scanner.scan_line(input);
+        assert_eq!(matches.len(), 1);
+        assert_eq!(&input[matches[0].range.clone()], "192.168.1.1");
+    }
+
+    #[test]
+    fn scanner_dispatch_finds_datetime() {
+        let finders: Vec<Box<dyn Finder>> =
+            vec![Box::new(crate::datetime::Datetime::default())];
+        let scanner = Scanner::new(finders);
+        let input = "at 2024-01-15T10:30:00Z end";
+        let matches = scanner.scan_line(input);
+        assert_eq!(matches.len(), 1);
+        assert_eq!(&input[matches[0].range.clone()], "2024-01-15T10:30:00Z");
+    }
+
+    #[test]
+    fn scanner_many_finders() {
+        let finders: Vec<Box<dyn Finder>> = vec![
+            Box::new(crate::hash::Hash::default()),
+            Box::new(crate::email::Email::default()),
+            Box::new(crate::env::Env::default()),
+            Box::new(crate::json::Json::default()),
+            Box::new(crate::ip::Ip::default()),
+        ];
+        let scanner = Scanner::new(finders);
+        let input = r#"192.168.1.1 user@example.com $HOME {"key": "val"} 5d41402abc4b2a76b9719d911017c592"#;
+        let matches = scanner.scan_line(input);
+        assert_eq!(matches.len(), 5);
+        assert_eq!(&input[matches[0].range.clone()], "192.168.1.1");
+        assert_eq!(&input[matches[1].range.clone()], "user@example.com");
+        assert_eq!(&input[matches[2].range.clone()], "$HOME");
+        assert_eq!(&input[matches[3].range.clone()], r#"{"key": "val"}"#);
+        assert_eq!(
+            &input[matches[4].range.clone()],
+            "5d41402abc4b2a76b9719d911017c592"
+        );
+    }
+
+    // --- Edge cases: single byte inputs ---
+
+    #[test]
+    fn scanner_single_byte_inputs() {
+        let finders: Vec<Box<dyn Finder>> = vec![
+            Box::new(crate::hash::Hash::default()),
+            Box::new(crate::email::Email::default()),
+            Box::new(crate::env::Env::default()),
+            Box::new(crate::ip::Ip::default()),
+            Box::new(crate::json::Json::default()),
+            Box::new(crate::color::Color::default()),
+            Box::new(crate::uuid::Uuid::default()),
+        ];
+        let scanner = Scanner::new(finders);
+        for b in 0..=127u8 {
+            let s = String::from(b as char);
+            let _ = scanner.scan_line(&s);
+        }
+    }
+
+    #[test]
+    fn scanner_two_byte_combinations() {
+        let finders: Vec<Box<dyn Finder>> = vec![
+            Box::new(crate::env::Env::default()),
+            Box::new(crate::json::Json::default()),
+            Box::new(crate::color::Color::default()),
+        ];
+        let scanner = Scanner::new(finders);
+        let interesting = b"${}[]#rgb()0aA@:/.~+-\"\\";
+        for &a in interesting {
+            for &b in interesting {
+                let s = String::from_utf8(vec![a, b]).unwrap();
+                let _ = scanner.scan_line(&s);
+            }
+        }
+    }
+
+    // --- Edge cases: repeated delimiters ---
+
+    #[test]
+    fn scanner_repeated_dollars() {
+        let finders: Vec<Box<dyn Finder>> =
+            vec![Box::new(crate::env::Env::default())];
+        let scanner = Scanner::new(finders);
+        assert!(scanner.scan_line("$$$").is_empty());
+        assert!(scanner.scan_line("$$$$").is_empty());
+    }
+
+    #[test]
+    fn scanner_repeated_hashes() {
+        let finders: Vec<Box<dyn Finder>> =
+            vec![Box::new(crate::color::Color::default())];
+        let scanner = Scanner::new(finders);
+        assert!(scanner.scan_line("###").is_empty());
+    }
+
+    #[test]
+    fn scanner_repeated_brackets() {
+        let finders: Vec<Box<dyn Finder>> =
+            vec![Box::new(crate::json::Json::default())];
+        let scanner = Scanner::new(finders);
+        let matches = scanner.scan_line("{}{}{}");
+        assert_eq!(matches.len(), 3);
+    }
+
+    #[test]
+    fn scanner_repeated_dots() {
+        let finders: Vec<Box<dyn Finder>> =
+            vec![Box::new(crate::ip::Ip::default())];
+        let scanner = Scanner::new(finders);
+        assert!(scanner.scan_line("....").is_empty());
+    }
+
+    // --- Edge cases: only whitespace ---
+
+    #[test]
+    fn scanner_whitespace() {
+        let finders: Vec<Box<dyn Finder>> = vec![
+            Box::new(crate::hash::Hash::default()),
+            Box::new(crate::email::Email::default()),
+        ];
+        let scanner = Scanner::new(finders);
+        assert!(scanner.scan_line("   \t\n  ").is_empty());
+    }
+
+    // --- Edge cases: very long lines ---
+
+    #[test]
+    fn scanner_long_hex_run() {
+        let finders: Vec<Box<dyn Finder>> =
+            vec![Box::new(crate::hash::Hash::default())];
+        let scanner = Scanner::new(finders);
+        let long_hex = "a".repeat(10000);
+        assert!(scanner.scan_line(&long_hex).is_empty());
+    }
+
+    #[test]
+    fn scanner_many_matches_in_line() {
+        let finders: Vec<Box<dyn Finder>> =
+            vec![Box::new(crate::env::Env::default())];
+        let scanner = Scanner::new(finders);
+        let input = (0..100).map(|i| format!("$VAR{}", i)).collect::<Vec<_>>().join(" ");
+        let matches = scanner.scan_line(&input);
+        assert_eq!(matches.len(), 100);
+    }
+
+    // --- Edge cases: adjacent matches ---
+
+    #[test]
+    fn scanner_adjacent_env_vars() {
+        let finders: Vec<Box<dyn Finder>> =
+            vec![Box::new(crate::env::Env::default())];
+        let scanner = Scanner::new(finders);
+        let input = "$A$B$C";
+        let matches = scanner.scan_line(input);
+        let texts: Vec<&str> = matches.iter().map(|m| &input[m.range.clone()]).collect();
+        assert_eq!(texts, vec!["$A", "$B", "$C"]);
+    }
+
+    #[test]
+    fn scanner_adjacent_json_objects() {
+        let finders: Vec<Box<dyn Finder>> =
+            vec![Box::new(crate::json::Json::default())];
+        let scanner = Scanner::new(finders);
+        let input = r#"{"a":1}{"b":2}[3]"#;
+        let matches = scanner.scan_line(input);
+        let texts: Vec<&str> = matches.iter().map(|m| &input[m.range.clone()]).collect();
+        assert_eq!(texts, vec![r#"{"a":1}"#, r#"{"b":2}"#, "[3]"]);
+    }
+
+    // --- Edge cases: prescan correctness ---
+
+    #[test]
+    fn prescan_all_byte_classes() {
+        let input = b"09afAF gZ@$#{}[]:./~+(- ";
+        let cl = prescan(input);
+        assert_ne!(cl & CL_DIGIT, 0);
+        assert_ne!(cl & CL_HEX_ALPHA, 0);
+        assert_ne!(cl & CL_ALPHA_OTHER, 0);
+        assert_ne!(cl & CL_AT, 0);
+        assert_ne!(cl & CL_DOLLAR, 0);
+        assert_ne!(cl & CL_HASH, 0);
+        assert_ne!(cl & CL_OPEN_BRACE, 0);
+        assert_ne!(cl & CL_OPEN_BRACKET, 0);
+        assert_ne!(cl & CL_COLON, 0);
+        assert_ne!(cl & CL_DOT, 0);
+        assert_ne!(cl & CL_SLASH, 0);
+        assert_ne!(cl & CL_TILDE, 0);
+        assert_ne!(cl & CL_PLUS, 0);
+        assert_ne!(cl & CL_OPEN_PAREN, 0);
+        assert_ne!(cl & CL_DASH, 0);
+    }
+
+    #[test]
+    fn prescan_high_bytes_have_no_class() {
+        for b in 128..=255u8 {
+            assert_eq!(BYTE_CLASSES[b as usize], 0, "byte {} should have no class", b);
+        }
+    }
+
+    // --- Edge cases: dispatch table ---
+
+    #[test]
+    fn dispatch_table_env_only_dollar() {
+        let finders: Vec<Box<dyn Finder>> =
+            vec![Box::new(crate::env::Env::default())];
+        let scanner = Scanner::new(finders);
+        for b in 0..=255u8 {
+            if b == b'$' {
+                assert_ne!(scanner.dispatch[b as usize], 0);
+            } else {
+                assert_eq!(scanner.dispatch[b as usize], 0);
+            }
+        }
+    }
+
+    #[test]
+    fn dispatch_table_color_selective() {
+        let finders: Vec<Box<dyn Finder>> =
+            vec![Box::new(crate::color::Color::default())];
+        let scanner = Scanner::new(finders);
+        assert_ne!(scanner.dispatch[b'#' as usize], 0);
+        assert_ne!(scanner.dispatch[b'r' as usize], 0);
+        assert_ne!(scanner.dispatch[b'R' as usize], 0);
+        assert_ne!(scanner.dispatch[b'h' as usize], 0);
+        assert_ne!(scanner.dispatch[b'H' as usize], 0);
+        assert_eq!(scanner.dispatch[b'x' as usize], 0);
+        assert_eq!(scanner.dispatch[b' ' as usize], 0);
+    }
+
+    #[test]
+    fn scanner_scan_line_first_with_no_matches() {
+        let finders: Vec<Box<dyn Finder>> =
+            vec![Box::new(crate::email::Email::default())];
+        let scanner = Scanner::new(finders);
+        assert!(scanner.scan_line_first("no at sign").is_none());
+    }
+
+    #[test]
+    fn scanner_scan_line_first_prescan_skip() {
+        let finders: Vec<Box<dyn Finder>> =
+            vec![Box::new(crate::email::Email::default())];
+        let scanner = Scanner::new(finders);
+        assert!(scanner.scan_line_first("no matches possible").is_none());
+    }
+}

--- a/squeeze/scanner.rs
+++ b/squeeze/scanner.rs
@@ -78,40 +78,72 @@ const fn build_byte_class_table() -> [u16; 256] {
 
 static BYTE_CLASSES: [u16; 256] = build_byte_class_table();
 
+#[inline]
 fn prescan(input: &[u8]) -> u16 {
     let mut classes = 0u16;
-    for &b in input {
+    let (prefix, chunks, suffix) = unsafe { input.align_to::<u64>() };
+    for &b in prefix {
+        classes |= BYTE_CLASSES[b as usize];
+    }
+    for &chunk in chunks {
+        let bytes = chunk.to_ne_bytes();
+        classes |= BYTE_CLASSES[bytes[0] as usize]
+            | BYTE_CLASSES[bytes[1] as usize]
+            | BYTE_CLASSES[bytes[2] as usize]
+            | BYTE_CLASSES[bytes[3] as usize]
+            | BYTE_CLASSES[bytes[4] as usize]
+            | BYTE_CLASSES[bytes[5] as usize]
+            | BYTE_CLASSES[bytes[6] as usize]
+            | BYTE_CLASSES[bytes[7] as usize];
+        if classes == u16::MAX {
+            return classes;
+        }
+    }
+    for &b in suffix {
         classes |= BYTE_CLASSES[b as usize];
     }
     classes
 }
 
-fn can_skip_finder(id: &str, cl: u16) -> bool {
+fn required_classes(id: &str) -> &'static [(u16, bool)] {
     match id {
-        "cidr" => (cl & CL_DIGIT) == 0 || (cl & CL_SLASH) == 0,
-        "codetag" => (cl & CL_COLON) == 0,
-        "color" => (cl & CL_HASH) == 0 && (cl & (CL_ALPHA_OTHER | CL_HEX_ALPHA)) == 0,
-        "datetime" => (cl & CL_DIGIT) == 0,
-        "email" => (cl & CL_AT) == 0,
-        "emoji" => false,
-        "env" => (cl & CL_DOLLAR) == 0,
-        "hash" => (cl & CL_HEX) == 0,
-        "ip" => (cl & (CL_DIGIT | CL_HEX_ALPHA | CL_COLON | CL_OPEN_BRACKET)) == 0,
-        "json" => (cl & (CL_OPEN_BRACE | CL_OPEN_BRACKET)) == 0,
-        "jwt" => (cl & CL_HEX_ALPHA) == 0,
-        "mac" => {
-            (cl & CL_HEX) == 0
-                || ((cl & CL_COLON) == 0 && (cl & CL_DASH) == 0 && (cl & CL_DOT) == 0)
-        }
-        "mirror" => false,
-        "path" => (cl & (CL_SLASH | CL_DOT | CL_TILDE)) == 0,
-        "phone" => (cl & (CL_DIGIT | CL_PLUS | CL_OPEN_PAREN)) == 0,
-        "semver" => (cl & CL_DIGIT) == 0 || (cl & CL_DOT) == 0,
-        "uri" => (cl & CL_COLON) == 0,
-        "uuid" => (cl & CL_HEX) == 0 || (cl & CL_DASH) == 0,
-        _ => false,
+        "cidr" => &[(CL_DIGIT, true), (CL_SLASH, true)],
+        "codetag" => &[(CL_COLON, true)],
+        "color" => &[(CL_HASH | CL_ALPHA_OTHER | CL_HEX_ALPHA, false)],
+        "datetime" => &[(CL_DIGIT, true)],
+        "email" => &[(CL_AT, true)],
+        "emoji" => &[],
+        "env" => &[(CL_DOLLAR, true)],
+        "hash" => &[(CL_HEX, false)],
+        "ip" => &[(CL_DIGIT | CL_HEX_ALPHA | CL_COLON | CL_OPEN_BRACKET, false)],
+        "json" => &[(CL_OPEN_BRACE | CL_OPEN_BRACKET, false)],
+        "jwt" => &[(CL_HEX_ALPHA, false)],
+        "mac" => &[(CL_HEX, false), (CL_COLON | CL_DASH | CL_DOT, false)],
+        "mirror" => &[],
+        "path" => &[(CL_SLASH | CL_DOT | CL_TILDE, false)],
+        "phone" => &[(CL_DIGIT | CL_PLUS | CL_OPEN_PAREN, false)],
+        "semver" => &[(CL_DIGIT, true), (CL_DOT, true)],
+        "uri" => &[(CL_COLON, true)],
+        "uuid" => &[(CL_HEX, false), (CL_DASH, true)],
+        _ => &[],
     }
 }
+
+#[inline]
+fn can_skip_with_mask(cl: u16, required: &[(u16, bool)]) -> bool {
+    for &(mask, all_required) in required {
+        if all_required {
+            if (cl & mask) == 0 {
+                return true;
+            }
+        } else if (cl & mask) == 0 {
+            return true;
+        }
+    }
+    false
+}
+
+const MAX_FINDERS: usize = 32;
 
 pub struct Match {
     pub finder_index: usize,
@@ -123,15 +155,19 @@ pub struct Scanner {
     dispatch: [u32; 256],
     dispatch_mask: u32,
     scan_mask: u32,
+    skip_requirements: Vec<&'static [(u16, bool)]>,
 }
 
 impl Scanner {
     pub fn new(finders: Vec<Box<dyn Finder>>) -> Self {
-        assert!(finders.len() <= 32);
+        assert!(finders.len() <= MAX_FINDERS);
 
         let mut dispatch = [0u32; 256];
         let mut dispatch_mask = 0u32;
         let mut scan_mask = 0u32;
+
+        let skip_requirements: Vec<&'static [(u16, bool)]> =
+            finders.iter().map(|f| required_classes(f.id())).collect();
 
         for (i, finder) in finders.iter().enumerate() {
             let bit = 1u32 << i;
@@ -152,11 +188,23 @@ impl Scanner {
             dispatch,
             dispatch_mask,
             scan_mask,
+            skip_requirements,
         }
     }
 
     pub fn finders(&self) -> &[Box<dyn Finder>] {
         &self.finders
+    }
+
+    #[inline]
+    fn compute_active(&self, line_classes: u16) -> u32 {
+        let mut active = 0u32;
+        for (i, req) in self.skip_requirements.iter().enumerate() {
+            if !can_skip_with_mask(line_classes, req) {
+                active |= 1u32 << i;
+            }
+        }
+        active
     }
 
     pub fn scan_line(&self, line: &str) -> Vec<Match> {
@@ -166,13 +214,7 @@ impl Scanner {
         }
 
         let line_classes = prescan(input);
-
-        let mut active = 0u32;
-        for (i, finder) in self.finders.iter().enumerate() {
-            if !can_skip_finder(finder.id(), line_classes) {
-                active |= 1u32 << i;
-            }
-        }
+        let active = self.compute_active(line_classes);
         if active == 0 {
             return Vec::new();
         }
@@ -181,10 +223,10 @@ impl Scanner {
 
         let active_scan = active & self.scan_mask;
         if active_scan != 0 {
-            for i in 0..self.finders.len() {
-                if (active_scan & (1u32 << i)) == 0 {
-                    continue;
-                }
+            let mut bits = active_scan;
+            while bits != 0 {
+                let i = bits.trailing_zeros() as usize;
+                bits &= bits - 1;
                 let finder = &self.finders[i];
                 let mut idx = 0;
                 while idx < line.len() {
@@ -203,7 +245,7 @@ impl Scanner {
 
         let active_dispatch = active & self.dispatch_mask;
         if active_dispatch != 0 {
-            let mut finder_pos = vec![0usize; self.finders.len()];
+            let mut finder_pos = [0usize; MAX_FINDERS];
 
             for pos in 0..input.len() {
                 let mut candidates = self.dispatch[input[pos] as usize] & active_dispatch;
@@ -225,7 +267,7 @@ impl Scanner {
             }
         }
 
-        matches.sort_by(|a, b| {
+        matches.sort_unstable_by(|a, b| {
             a.range
                 .start
                 .cmp(&b.range.start)
@@ -242,33 +284,67 @@ impl Scanner {
         }
 
         let line_classes = prescan(input);
-
-        let mut active = 0u32;
-        for (i, finder) in self.finders.iter().enumerate() {
-            if !can_skip_finder(finder.id(), line_classes) {
-                active |= 1u32 << i;
-            }
-        }
+        let active = self.compute_active(line_classes);
         if active == 0 {
             return None;
         }
 
         let mut best: Option<Match> = None;
 
-        for (i, finder) in self.finders.iter().enumerate() {
-            if (active & (1u32 << i)) == 0 {
-                continue;
+        let active_scan = active & self.scan_mask;
+        if active_scan != 0 {
+            let mut bits = active_scan;
+            while bits != 0 {
+                let i = bits.trailing_zeros() as usize;
+                bits &= bits - 1;
+                if let Some(range) = self.finders[i].find(line) {
+                    let dominated = match &best {
+                        Some(b) => range.start >= b.range.start,
+                        None => false,
+                    };
+                    if !dominated {
+                        best = Some(Match {
+                            finder_index: i,
+                            range,
+                        });
+                        if best.as_ref().unwrap().range.start == 0 {
+                            return best;
+                        }
+                    }
+                }
             }
-            if let Some(range) = finder.find(line) {
-                let is_better = match &best {
-                    None => true,
-                    Some(b) => range.start < b.range.start,
-                };
-                if is_better {
-                    best = Some(Match {
-                        finder_index: i,
-                        range,
-                    });
+        }
+
+        let active_dispatch = active & self.dispatch_mask;
+        if active_dispatch != 0 {
+            let limit = best.as_ref().map_or(input.len(), |b| b.range.start);
+            let mut finder_pos = [0usize; MAX_FINDERS];
+
+            for pos in 0..limit {
+                let mut candidates = self.dispatch[input[pos] as usize] & active_dispatch;
+                while candidates != 0 {
+                    let i = candidates.trailing_zeros() as usize;
+                    candidates &= candidates - 1;
+
+                    if pos < finder_pos[i] {
+                        continue;
+                    }
+                    if let Some(range) = self.finders[i].try_at(input, pos) {
+                        finder_pos[i] = range.end;
+                        let dominated = match &best {
+                            Some(b) => range.start >= b.range.start,
+                            None => false,
+                        };
+                        if !dominated {
+                            best = Some(Match {
+                                finder_index: i,
+                                range,
+                            });
+                            if best.as_ref().unwrap().range.start == 0 {
+                                return best;
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -312,73 +388,73 @@ mod tests {
     #[test]
     fn can_skip_email_without_at() {
         let cl = prescan(b"hello world");
-        assert!(can_skip_finder("email", cl));
+        assert!(can_skip_with_mask(cl, required_classes("email")));
     }
 
     #[test]
     fn cannot_skip_email_with_at() {
         let cl = prescan(b"user@example.com");
-        assert!(!can_skip_finder("email", cl));
+        assert!(!can_skip_with_mask(cl, required_classes("email")));
     }
 
     #[test]
     fn can_skip_env_without_dollar() {
         let cl = prescan(b"no vars here");
-        assert!(can_skip_finder("env", cl));
+        assert!(can_skip_with_mask(cl, required_classes("env")));
     }
 
     #[test]
     fn can_skip_json_without_brackets() {
         let cl = prescan(b"no json here");
-        assert!(can_skip_finder("json", cl));
+        assert!(can_skip_with_mask(cl, required_classes("json")));
     }
 
     #[test]
     fn can_skip_uri_without_colon() {
         let cl = prescan(b"no uris here");
-        assert!(can_skip_finder("uri", cl));
+        assert!(can_skip_with_mask(cl, required_classes("uri")));
     }
 
     #[test]
     fn can_skip_uuid_without_dash() {
         let cl = prescan(b"abcdef1234567890");
-        assert!(can_skip_finder("uuid", cl));
+        assert!(can_skip_with_mask(cl, required_classes("uuid")));
     }
 
     #[test]
     fn cannot_skip_mirror() {
         let cl = prescan(b"anything");
-        assert!(!can_skip_finder("mirror", cl));
+        assert!(!can_skip_with_mask(cl, required_classes("mirror")));
     }
 
     #[test]
     fn can_skip_hash_without_hex() {
         let cl = prescan(b"no hx zzz");
-        assert!(can_skip_finder("hash", cl));
+        assert!(can_skip_with_mask(cl, required_classes("hash")));
     }
 
     #[test]
     fn can_skip_mac_without_separator() {
         let cl = prescan(b"aabbccddeeff");
-        assert!(can_skip_finder("mac", cl));
+        assert!(can_skip_with_mask(cl, required_classes("mac")));
     }
 
     #[test]
     fn can_skip_semver_without_dot() {
         let cl = prescan(b"version 100");
-        assert!(can_skip_finder("semver", cl));
+        assert!(can_skip_with_mask(cl, required_classes("semver")));
     }
 
     #[test]
     fn can_skip_cidr_without_slash() {
         let cl = prescan(b"192.168.1.0");
-        assert!(can_skip_finder("cidr", cl));
+        assert!(can_skip_with_mask(cl, required_classes("cidr")));
     }
 
     #[test]
     fn can_skip_path_without_prefix() {
         let cl = prescan(b"no paths here");
-        assert!(can_skip_finder("path", cl));
+        assert!(can_skip_with_mask(cl, required_classes("path")));
     }
 
     #[test]
@@ -389,16 +465,14 @@ mod tests {
 
     #[test]
     fn scanner_empty_line() {
-        let finders: Vec<Box<dyn Finder>> =
-            vec![Box::new(crate::mirror::Mirror::default())];
+        let finders: Vec<Box<dyn Finder>> = vec![Box::new(crate::mirror::Mirror::default())];
         let scanner = Scanner::new(finders);
         assert!(scanner.scan_line("").is_empty());
     }
 
     #[test]
     fn scanner_mirror_matches_everything() {
-        let finders: Vec<Box<dyn Finder>> =
-            vec![Box::new(crate::mirror::Mirror::default())];
+        let finders: Vec<Box<dyn Finder>> = vec![Box::new(crate::mirror::Mirror::default())];
         let scanner = Scanner::new(finders);
         let matches = scanner.scan_line("hello world");
         assert_eq!(matches.len(), 1);
@@ -407,8 +481,7 @@ mod tests {
 
     #[test]
     fn scanner_prescan_skips_impossible_finders() {
-        let finders: Vec<Box<dyn Finder>> =
-            vec![Box::new(crate::email::Email::default())];
+        let finders: Vec<Box<dyn Finder>> = vec![Box::new(crate::email::Email::default())];
         let scanner = Scanner::new(finders);
         let matches = scanner.scan_line("no at sign here");
         assert!(matches.is_empty());
@@ -416,8 +489,7 @@ mod tests {
 
     #[test]
     fn scanner_dispatch_finds_hash() {
-        let finders: Vec<Box<dyn Finder>> =
-            vec![Box::new(crate::hash::Hash::default())];
+        let finders: Vec<Box<dyn Finder>> = vec![Box::new(crate::hash::Hash::default())];
         let scanner = Scanner::new(finders);
         let input = "md5: 5d41402abc4b2a76b9719d911017c592";
         let matches = scanner.scan_line(input);
@@ -430,8 +502,7 @@ mod tests {
 
     #[test]
     fn scanner_dispatch_finds_multiple_hashes() {
-        let finders: Vec<Box<dyn Finder>> =
-            vec![Box::new(crate::hash::Hash::default())];
+        let finders: Vec<Box<dyn Finder>> = vec![Box::new(crate::hash::Hash::default())];
         let scanner = Scanner::new(finders);
         let input = "5d41402abc4b2a76b9719d911017c592 and 2aae6c35c94fcfb415dbe95f408b9ce91ee846ed";
         let matches = scanner.scan_line(input);
@@ -490,8 +561,7 @@ mod tests {
 
     #[test]
     fn scanner_dispatch_finds_env() {
-        let finders: Vec<Box<dyn Finder>> =
-            vec![Box::new(crate::env::Env::default())];
+        let finders: Vec<Box<dyn Finder>> = vec![Box::new(crate::env::Env::default())];
         let scanner = Scanner::new(finders);
         let input = "use $HOME and ${PATH}";
         let matches = scanner.scan_line(input);
@@ -502,8 +572,7 @@ mod tests {
 
     #[test]
     fn scanner_dispatch_finds_json() {
-        let finders: Vec<Box<dyn Finder>> =
-            vec![Box::new(crate::json::Json::default())];
+        let finders: Vec<Box<dyn Finder>> = vec![Box::new(crate::json::Json::default())];
         let scanner = Scanner::new(finders);
         let input = r#"data: {"key": "value"} end"#;
         let matches = scanner.scan_line(input);
@@ -513,8 +582,7 @@ mod tests {
 
     #[test]
     fn scanner_dispatch_finds_uuid() {
-        let finders: Vec<Box<dyn Finder>> =
-            vec![Box::new(crate::uuid::Uuid::default())];
+        let finders: Vec<Box<dyn Finder>> = vec![Box::new(crate::uuid::Uuid::default())];
         let scanner = Scanner::new(finders);
         let input = "id: 550e8400-e29b-41d4-a716-446655440000 end";
         let matches = scanner.scan_line(input);
@@ -527,8 +595,7 @@ mod tests {
 
     #[test]
     fn scanner_dispatch_finds_color() {
-        let finders: Vec<Box<dyn Finder>> =
-            vec![Box::new(crate::color::Color::default())];
+        let finders: Vec<Box<dyn Finder>> = vec![Box::new(crate::color::Color::default())];
         let scanner = Scanner::new(finders);
         let input = "color: #ff00aa and rgb(0, 255, 0)";
         let matches = scanner.scan_line(input);
@@ -539,8 +606,7 @@ mod tests {
 
     #[test]
     fn scanner_dispatch_finds_ip() {
-        let finders: Vec<Box<dyn Finder>> =
-            vec![Box::new(crate::ip::Ip::default())];
+        let finders: Vec<Box<dyn Finder>> = vec![Box::new(crate::ip::Ip::default())];
         let scanner = Scanner::new(finders);
         let input = "connect to 192.168.1.1 now";
         let matches = scanner.scan_line(input);
@@ -550,8 +616,7 @@ mod tests {
 
     #[test]
     fn scanner_dispatch_finds_datetime() {
-        let finders: Vec<Box<dyn Finder>> =
-            vec![Box::new(crate::datetime::Datetime::default())];
+        let finders: Vec<Box<dyn Finder>> = vec![Box::new(crate::datetime::Datetime::default())];
         let scanner = Scanner::new(finders);
         let input = "at 2024-01-15T10:30:00Z end";
         let matches = scanner.scan_line(input);
@@ -569,7 +634,8 @@ mod tests {
             Box::new(crate::ip::Ip::default()),
         ];
         let scanner = Scanner::new(finders);
-        let input = r#"192.168.1.1 user@example.com $HOME {"key": "val"} 5d41402abc4b2a76b9719d911017c592"#;
+        let input =
+            r#"192.168.1.1 user@example.com $HOME {"key": "val"} 5d41402abc4b2a76b9719d911017c592"#;
         let matches = scanner.scan_line(input);
         assert_eq!(matches.len(), 5);
         assert_eq!(&input[matches[0].range.clone()], "192.168.1.1");
@@ -623,8 +689,7 @@ mod tests {
 
     #[test]
     fn scanner_repeated_dollars() {
-        let finders: Vec<Box<dyn Finder>> =
-            vec![Box::new(crate::env::Env::default())];
+        let finders: Vec<Box<dyn Finder>> = vec![Box::new(crate::env::Env::default())];
         let scanner = Scanner::new(finders);
         assert!(scanner.scan_line("$$$").is_empty());
         assert!(scanner.scan_line("$$$$").is_empty());
@@ -632,16 +697,14 @@ mod tests {
 
     #[test]
     fn scanner_repeated_hashes() {
-        let finders: Vec<Box<dyn Finder>> =
-            vec![Box::new(crate::color::Color::default())];
+        let finders: Vec<Box<dyn Finder>> = vec![Box::new(crate::color::Color::default())];
         let scanner = Scanner::new(finders);
         assert!(scanner.scan_line("###").is_empty());
     }
 
     #[test]
     fn scanner_repeated_brackets() {
-        let finders: Vec<Box<dyn Finder>> =
-            vec![Box::new(crate::json::Json::default())];
+        let finders: Vec<Box<dyn Finder>> = vec![Box::new(crate::json::Json::default())];
         let scanner = Scanner::new(finders);
         let matches = scanner.scan_line("{}{}{}");
         assert_eq!(matches.len(), 3);
@@ -649,8 +712,7 @@ mod tests {
 
     #[test]
     fn scanner_repeated_dots() {
-        let finders: Vec<Box<dyn Finder>> =
-            vec![Box::new(crate::ip::Ip::default())];
+        let finders: Vec<Box<dyn Finder>> = vec![Box::new(crate::ip::Ip::default())];
         let scanner = Scanner::new(finders);
         assert!(scanner.scan_line("....").is_empty());
     }
@@ -671,8 +733,7 @@ mod tests {
 
     #[test]
     fn scanner_long_hex_run() {
-        let finders: Vec<Box<dyn Finder>> =
-            vec![Box::new(crate::hash::Hash::default())];
+        let finders: Vec<Box<dyn Finder>> = vec![Box::new(crate::hash::Hash::default())];
         let scanner = Scanner::new(finders);
         let long_hex = "a".repeat(10000);
         assert!(scanner.scan_line(&long_hex).is_empty());
@@ -680,10 +741,12 @@ mod tests {
 
     #[test]
     fn scanner_many_matches_in_line() {
-        let finders: Vec<Box<dyn Finder>> =
-            vec![Box::new(crate::env::Env::default())];
+        let finders: Vec<Box<dyn Finder>> = vec![Box::new(crate::env::Env::default())];
         let scanner = Scanner::new(finders);
-        let input = (0..100).map(|i| format!("$VAR{}", i)).collect::<Vec<_>>().join(" ");
+        let input = (0..100)
+            .map(|i| format!("$VAR{}", i))
+            .collect::<Vec<_>>()
+            .join(" ");
         let matches = scanner.scan_line(&input);
         assert_eq!(matches.len(), 100);
     }
@@ -692,8 +755,7 @@ mod tests {
 
     #[test]
     fn scanner_adjacent_env_vars() {
-        let finders: Vec<Box<dyn Finder>> =
-            vec![Box::new(crate::env::Env::default())];
+        let finders: Vec<Box<dyn Finder>> = vec![Box::new(crate::env::Env::default())];
         let scanner = Scanner::new(finders);
         let input = "$A$B$C";
         let matches = scanner.scan_line(input);
@@ -703,8 +765,7 @@ mod tests {
 
     #[test]
     fn scanner_adjacent_json_objects() {
-        let finders: Vec<Box<dyn Finder>> =
-            vec![Box::new(crate::json::Json::default())];
+        let finders: Vec<Box<dyn Finder>> = vec![Box::new(crate::json::Json::default())];
         let scanner = Scanner::new(finders);
         let input = r#"{"a":1}{"b":2}[3]"#;
         let matches = scanner.scan_line(input);
@@ -738,7 +799,11 @@ mod tests {
     #[test]
     fn prescan_high_bytes_have_no_class() {
         for b in 128..=255u8 {
-            assert_eq!(BYTE_CLASSES[b as usize], 0, "byte {} should have no class", b);
+            assert_eq!(
+                BYTE_CLASSES[b as usize], 0,
+                "byte {} should have no class",
+                b
+            );
         }
     }
 
@@ -746,8 +811,7 @@ mod tests {
 
     #[test]
     fn dispatch_table_env_only_dollar() {
-        let finders: Vec<Box<dyn Finder>> =
-            vec![Box::new(crate::env::Env::default())];
+        let finders: Vec<Box<dyn Finder>> = vec![Box::new(crate::env::Env::default())];
         let scanner = Scanner::new(finders);
         for b in 0..=255u8 {
             if b == b'$' {
@@ -760,8 +824,7 @@ mod tests {
 
     #[test]
     fn dispatch_table_color_selective() {
-        let finders: Vec<Box<dyn Finder>> =
-            vec![Box::new(crate::color::Color::default())];
+        let finders: Vec<Box<dyn Finder>> = vec![Box::new(crate::color::Color::default())];
         let scanner = Scanner::new(finders);
         assert_ne!(scanner.dispatch[b'#' as usize], 0);
         assert_ne!(scanner.dispatch[b'r' as usize], 0);
@@ -774,16 +837,14 @@ mod tests {
 
     #[test]
     fn scanner_scan_line_first_with_no_matches() {
-        let finders: Vec<Box<dyn Finder>> =
-            vec![Box::new(crate::email::Email::default())];
+        let finders: Vec<Box<dyn Finder>> = vec![Box::new(crate::email::Email::default())];
         let scanner = Scanner::new(finders);
         assert!(scanner.scan_line_first("no at sign").is_none());
     }
 
     #[test]
     fn scanner_scan_line_first_prescan_skip() {
-        let finders: Vec<Box<dyn Finder>> =
-            vec![Box::new(crate::email::Email::default())];
+        let finders: Vec<Box<dyn Finder>> = vec![Box::new(crate::email::Email::default())];
         let scanner = Scanner::new(finders);
         assert!(scanner.scan_line_first("no matches possible").is_none());
     }

--- a/squeeze/scanner.rs
+++ b/squeeze/scanner.rs
@@ -17,6 +17,7 @@ const CL_PLUS: u16 = 1 << 12;
 const CL_OPEN_PAREN: u16 = 1 << 13;
 const CL_DASH: u16 = 1 << 14;
 
+const CL_ALL_USED: u16 = (1 << 15) - 1;
 const CL_HEX: u16 = CL_DIGIT | CL_HEX_ALPHA;
 
 const fn build_byte_class_table() -> [u16; 256] {
@@ -81,25 +82,22 @@ static BYTE_CLASSES: [u16; 256] = build_byte_class_table();
 #[inline]
 fn prescan(input: &[u8]) -> u16 {
     let mut classes = 0u16;
-    let (prefix, chunks, suffix) = unsafe { input.align_to::<u64>() };
-    for &b in prefix {
-        classes |= BYTE_CLASSES[b as usize];
-    }
-    for &chunk in chunks {
-        let bytes = chunk.to_ne_bytes();
-        classes |= BYTE_CLASSES[bytes[0] as usize]
-            | BYTE_CLASSES[bytes[1] as usize]
-            | BYTE_CLASSES[bytes[2] as usize]
-            | BYTE_CLASSES[bytes[3] as usize]
-            | BYTE_CLASSES[bytes[4] as usize]
-            | BYTE_CLASSES[bytes[5] as usize]
-            | BYTE_CLASSES[bytes[6] as usize]
-            | BYTE_CLASSES[bytes[7] as usize];
-        if classes == u16::MAX {
+    let chunks = input.chunks_exact(8);
+    let remainder = chunks.remainder();
+    for chunk in chunks {
+        classes |= BYTE_CLASSES[chunk[0] as usize]
+            | BYTE_CLASSES[chunk[1] as usize]
+            | BYTE_CLASSES[chunk[2] as usize]
+            | BYTE_CLASSES[chunk[3] as usize]
+            | BYTE_CLASSES[chunk[4] as usize]
+            | BYTE_CLASSES[chunk[5] as usize]
+            | BYTE_CLASSES[chunk[6] as usize]
+            | BYTE_CLASSES[chunk[7] as usize];
+        if classes == CL_ALL_USED {
             return classes;
         }
     }
-    for &b in suffix {
+    for &b in remainder {
         classes |= BYTE_CLASSES[b as usize];
     }
     classes
@@ -133,7 +131,7 @@ fn required_classes(id: &str) -> &'static [(u16, bool)] {
 fn can_skip_with_mask(cl: u16, required: &[(u16, bool)]) -> bool {
     for &(mask, all_required) in required {
         if all_required {
-            if (cl & mask) == 0 {
+            if cl & mask != mask {
                 return true;
             }
         } else if (cl & mask) == 0 {
@@ -208,18 +206,24 @@ impl Scanner {
     }
 
     pub fn scan_line(&self, line: &str) -> Vec<Match> {
+        let mut matches = Vec::new();
+        self.scan_line_into(line, &mut matches);
+        matches
+    }
+
+    pub fn scan_line_into(&self, line: &str, matches: &mut Vec<Match>) {
+        matches.clear();
+
         let input = line.as_bytes();
         if input.is_empty() {
-            return Vec::new();
+            return;
         }
 
         let line_classes = prescan(input);
         let active = self.compute_active(line_classes);
         if active == 0 {
-            return Vec::new();
+            return;
         }
-
-        let mut matches = Vec::new();
 
         let active_scan = active & self.scan_mask;
         if active_scan != 0 {
@@ -273,8 +277,6 @@ impl Scanner {
                 .cmp(&b.range.start)
                 .then(a.finder_index.cmp(&b.finder_index))
         });
-
-        matches
     }
 
     pub fn scan_line_first(&self, line: &str) -> Option<Match> {
@@ -847,5 +849,161 @@ mod tests {
         let finders: Vec<Box<dyn Finder>> = vec![Box::new(crate::email::Email::default())];
         let scanner = Scanner::new(finders);
         assert!(scanner.scan_line_first("no matches possible").is_none());
+    }
+
+    // --- Regression: prescan early exit with all classes ---
+
+    #[test]
+    fn prescan_early_exit_fires_with_all_classes() {
+        let input = b"09afAF gZ@$#{}[]:./~+(- ";
+        let cl = prescan(input);
+        assert_eq!(cl, CL_ALL_USED);
+    }
+
+    #[test]
+    fn prescan_early_exit_on_long_input() {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(b"09afAF gZ@$#{}[]:./~+(- ");
+        buf.extend_from_slice(&[b'x'; 10000]);
+        let cl = prescan(&buf);
+        assert_eq!(cl, CL_ALL_USED);
+    }
+
+    // --- Regression: can_skip_with_mask all_required distinction ---
+
+    #[test]
+    fn can_skip_all_required_single_bit_present() {
+        let cl = CL_DIGIT | CL_SLASH;
+        assert!(!can_skip_with_mask(
+            cl,
+            &[(CL_DIGIT, true), (CL_SLASH, true)]
+        ));
+    }
+
+    #[test]
+    fn can_skip_all_required_missing_one() {
+        let cl = CL_DIGIT;
+        assert!(can_skip_with_mask(
+            cl,
+            &[(CL_DIGIT, true), (CL_SLASH, true)]
+        ));
+    }
+
+    #[test]
+    fn can_skip_any_required_at_least_one() {
+        let cl = CL_HASH;
+        assert!(!can_skip_with_mask(
+            cl,
+            &[(CL_HASH | CL_ALPHA_OTHER, false)]
+        ));
+    }
+
+    #[test]
+    fn can_skip_any_required_none_present() {
+        let cl = CL_DIGIT;
+        assert!(can_skip_with_mask(cl, &[(CL_HASH | CL_ALPHA_OTHER, false)]));
+    }
+
+    #[test]
+    fn can_skip_cidr_with_digit_but_no_slash() {
+        let cl = CL_DIGIT | CL_DOT;
+        assert!(can_skip_with_mask(cl, required_classes("cidr")));
+    }
+
+    #[test]
+    fn can_skip_semver_with_digit_but_no_dot() {
+        let cl = CL_DIGIT;
+        assert!(can_skip_with_mask(cl, required_classes("semver")));
+    }
+
+    #[test]
+    fn cannot_skip_semver_with_digit_and_dot() {
+        let cl = CL_DIGIT | CL_DOT;
+        assert!(!can_skip_with_mask(cl, required_classes("semver")));
+    }
+
+    // --- Regression: scan_line_into reuses buffer ---
+
+    #[test]
+    fn scan_line_into_reuses_buffer() {
+        let finders: Vec<Box<dyn Finder>> = vec![Box::new(crate::env::Env::default())];
+        let scanner = Scanner::new(finders);
+        let mut buf = Vec::new();
+
+        scanner.scan_line_into("$HOME here", &mut buf);
+        assert_eq!(buf.len(), 1);
+        assert_eq!(buf[0].range, 0..5);
+
+        scanner.scan_line_into("$PATH and $USER", &mut buf);
+        assert_eq!(buf.len(), 2);
+
+        scanner.scan_line_into("no vars", &mut buf);
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn scan_line_into_matches_scan_line() {
+        let finders: Vec<Box<dyn Finder>> = vec![
+            Box::new(crate::hash::Hash::default()),
+            Box::new(crate::email::Email::default()),
+            Box::new(crate::env::Env::default()),
+        ];
+        let scanner = Scanner::new(finders);
+        let input = "user@example.com $HOME 5d41402abc4b2a76b9719d911017c592";
+
+        let from_scan_line = scanner.scan_line(input);
+        let mut buf = Vec::new();
+        scanner.scan_line_into(input, &mut buf);
+
+        assert_eq!(from_scan_line.len(), buf.len());
+        for (a, b) in from_scan_line.iter().zip(buf.iter()) {
+            assert_eq!(a.range, b.range);
+            assert_eq!(a.finder_index, b.finder_index);
+        }
+    }
+
+    // --- Regression: all finders combined ---
+
+    #[test]
+    fn scanner_all_finders_no_panic() {
+        let mut codetag = crate::codetag::Codetag::default();
+        codetag.build_mnemonics_regex().unwrap();
+        let finders: Vec<Box<dyn Finder>> = vec![
+            Box::new(crate::cidr::Cidr::default()),
+            Box::new(codetag),
+            Box::new(crate::color::Color::default()),
+            Box::new(crate::datetime::Datetime::default()),
+            Box::new(crate::email::Email::default()),
+            Box::new(crate::emoji::Emoji::default()),
+            Box::new(crate::env::Env::default()),
+            Box::new(crate::hash::Hash::default()),
+            Box::new(crate::ip::Ip::default()),
+            Box::new(crate::json::Json::default()),
+            Box::new(crate::jwt::Jwt::default()),
+            Box::new(crate::mac::Mac::default()),
+            Box::new(crate::path::Path::default()),
+            Box::new(crate::phone::Phone::default()),
+            Box::new(crate::semver::Semver::default()),
+            Box::new(crate::uri::URI::default()),
+            Box::new(crate::uuid::Uuid::default()),
+        ];
+        let scanner = Scanner::new(finders);
+
+        for input in [
+            "",
+            " ",
+            "hello world",
+            "user@example.com",
+            "http://example.com",
+            "$HOME /etc/hosts 192.168.1.0/24",
+            "550e8400-e29b-41d4-a716-446655440000",
+            r#"{"key": "value"} TODO: fix this"#,
+            "v1.2.3 #ff00aa 2024-01-15T10:30:00Z",
+            "00:1A:2B:3C:4D:5E +14155551234",
+            "😀🎉 hello",
+        ] {
+            let _ = scanner.scan_line(input);
+            let _ = scanner.scan_line_first(input);
+        }
     }
 }

--- a/squeeze/semver.rs
+++ b/squeeze/semver.rs
@@ -52,6 +52,65 @@ impl Finder for Semver {
         "semver"
     }
 
+    fn dispatchable(&self) -> bool {
+        true
+    }
+
+    fn could_start_at(&self, byte: u8) -> bool {
+        byte.is_ascii_digit() || byte == b'v' || byte == b'V'
+    }
+
+    fn try_at(&self, input: &[u8], pos: usize) -> Option<Range<usize>> {
+        let start = pos;
+        let mut p = pos;
+
+        if p < input.len() && (input[p] == b'v' || input[p] == b'V') {
+            if p + 1 < input.len() && input[p + 1].is_ascii_digit() {
+                p += 1;
+            } else {
+                return None;
+            }
+        } else if p < input.len() && input[p].is_ascii_digit() {
+            // ok
+        } else {
+            return None;
+        }
+
+        if !Self::is_boundary_before(input, start) {
+            return None;
+        }
+
+        let major_end = Self::parse_digits(input, p)?;
+        if major_end >= input.len() || input[major_end] != b'.' {
+            return None;
+        }
+        let minor_end = Self::parse_digits(input, major_end + 1)?;
+        if minor_end >= input.len() || input[minor_end] != b'.' {
+            return None;
+        }
+        let patch_end = Self::parse_digits(input, minor_end + 1)?;
+
+        let mut end = patch_end;
+        if end < input.len() && input[end] == b'-' {
+            let pre_end = Self::parse_prerelease_or_build(input, end + 1);
+            if pre_end > end + 1 {
+                end = pre_end;
+            }
+        }
+        if end < input.len() && input[end] == b'+' {
+            let build_end = Self::parse_prerelease_or_build(input, end + 1);
+            if build_end > end + 1 {
+                end = build_end;
+            }
+        }
+
+        if Self::is_boundary_after(input, end) {
+            Some(start..end)
+        } else {
+            None
+        }
+    }
+
     fn find(&self, s: &str) -> Option<Range<usize>> {
         let input = s.as_bytes();
         let mut idx = 0;
@@ -303,5 +362,76 @@ mod tests {
     fn find_should_not_match_ip_address() {
         let finder = Semver::default();
         assert!(finder.find("192.168.1.1").is_none());
+    }
+
+    #[test]
+    fn try_at_simple() {
+        let finder = Semver::default();
+        let input = b"1.2.3 rest";
+        assert_eq!(finder.try_at(input, 0), Some(0..5));
+    }
+
+    #[test]
+    fn try_at_with_v_prefix() {
+        let finder = Semver::default();
+        let input = b"v1.2.3 rest";
+        assert_eq!(finder.try_at(input, 0), Some(0..6));
+    }
+
+    #[test]
+    fn try_at_preceded_by_alpha() {
+        let finder = Semver::default();
+        let input = b"a1.2.3";
+        assert!(finder.try_at(input, 1).is_none());
+    }
+
+    #[test]
+    fn try_at_preceded_by_dot() {
+        let finder = Semver::default();
+        let input = b".1.2.3";
+        assert!(finder.try_at(input, 1).is_none());
+    }
+
+    #[test]
+    fn try_at_v_without_digit() {
+        let finder = Semver::default();
+        let input = b"vx";
+        assert!(finder.try_at(input, 0).is_none());
+    }
+
+    #[test]
+    fn try_at_single_digit() {
+        let finder = Semver::default();
+        let input = b"1";
+        assert!(finder.try_at(input, 0).is_none());
+    }
+
+    #[test]
+    fn find_prerelease_with_dots() {
+        let finder = Semver::default();
+        let input = "1.0.0-alpha.1.2";
+        let range = finder.find(input).unwrap();
+        assert_eq!("1.0.0-alpha.1.2", &input[range]);
+    }
+
+    #[test]
+    fn find_build_with_dots() {
+        let finder = Semver::default();
+        let input = "1.0.0+build.1.2";
+        let range = finder.find(input).unwrap();
+        assert_eq!("1.0.0+build.1.2", &input[range]);
+    }
+
+    #[test]
+    fn find_rejects_trailing_dot_in_prerelease() {
+        let finder = Semver::default();
+        assert!(finder.find("1.0.0-beta.").is_none());
+    }
+
+    #[test]
+    fn find_prerelease_with_trailing_dot_in_text() {
+        let finder = Semver::default();
+        let input = "use 1.0.0-beta. done";
+        assert!(finder.find(input).is_none());
     }
 }

--- a/squeeze/tests/fuzz.rs
+++ b/squeeze/tests/fuzz.rs
@@ -1,6 +1,6 @@
 use proptest::prelude::*;
-use squeeze::scanner::Scanner;
 use squeeze::Finder;
+use squeeze::scanner::Scanner;
 use std::ops::Range;
 
 fn all_finders() -> Vec<Box<dyn Finder>> {

--- a/squeeze/tests/fuzz.rs
+++ b/squeeze/tests/fuzz.rs
@@ -1,0 +1,673 @@
+use proptest::prelude::*;
+use squeeze::scanner::Scanner;
+use squeeze::Finder;
+use std::ops::Range;
+
+fn all_finders() -> Vec<Box<dyn Finder>> {
+    let mut codetag = squeeze::codetag::Codetag::default();
+    codetag.build_mnemonics_regex().unwrap();
+
+    vec![
+        Box::new(squeeze::cidr::Cidr::default()),
+        Box::new(codetag),
+        Box::new(squeeze::color::Color::default()),
+        Box::new(squeeze::datetime::Datetime::default()),
+        Box::new(squeeze::email::Email::default()),
+        Box::new(squeeze::env::Env::default()),
+        Box::new(squeeze::hash::Hash::default()),
+        Box::new(squeeze::ip::Ip::default()),
+        Box::new(squeeze::json::Json::default()),
+        Box::new(squeeze::jwt::Jwt::default()),
+        Box::new(squeeze::mac::Mac::default()),
+        Box::new(squeeze::path::Path::default()),
+        Box::new(squeeze::phone::Phone::default()),
+        Box::new(squeeze::semver::Semver::default()),
+        Box::new(squeeze::uri::URI::default()),
+        Box::new(squeeze::uuid::Uuid::default()),
+    ]
+}
+
+fn old_style_find_all(finder: &dyn Finder, line: &str) -> Vec<Range<usize>> {
+    let mut results = Vec::new();
+    let mut idx = 0;
+    while idx < line.len() {
+        if let Some(range) = finder.find(&line[idx..]) {
+            results.push((idx + range.start)..(idx + range.end));
+            idx += range.end;
+        } else {
+            break;
+        }
+    }
+    results
+}
+
+fn collect_texts(line: &str, ranges: &[Range<usize>]) -> Vec<String> {
+    let mut texts: Vec<String> = ranges.iter().map(|r| line[r.clone()].to_string()).collect();
+    texts.sort();
+    texts
+}
+
+// --- Property-based tests ---
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(2000))]
+
+    #[test]
+    fn no_panic_on_arbitrary_utf8(s in "\\PC{0,200}") {
+        let finders = all_finders();
+        let scanner = Scanner::new(finders);
+        let _ = scanner.scan_line(&s);
+    }
+
+    #[test]
+    fn no_panic_on_arbitrary_ascii(s in "[\\x00-\\x7f]{0,300}") {
+        let finders = all_finders();
+        let scanner = Scanner::new(finders);
+        let _ = scanner.scan_line(&s);
+    }
+
+    #[test]
+    fn match_ranges_are_valid(s in "\\PC{0,200}") {
+        let finders = all_finders();
+        let scanner = Scanner::new(finders);
+        for m in scanner.scan_line(&s) {
+            prop_assert!(m.range.start <= m.range.end);
+            prop_assert!(m.range.end <= s.len());
+            prop_assert!(m.finder_index < scanner.finders().len());
+            // The range must be valid UTF-8 boundaries
+            prop_assert!(s.is_char_boundary(m.range.start));
+            prop_assert!(s.is_char_boundary(m.range.end));
+        }
+    }
+
+    #[test]
+    fn matches_are_position_sorted(s in "\\PC{0,200}") {
+        let finders = all_finders();
+        let scanner = Scanner::new(finders);
+        let matches = scanner.scan_line(&s);
+        for w in matches.windows(2) {
+            prop_assert!(w[0].range.start <= w[1].range.start);
+        }
+    }
+
+    #[test]
+    fn scan_line_first_returns_earliest(s in "\\PC{0,200}") {
+        let finders = all_finders();
+        let scanner = Scanner::new(finders);
+        let all = scanner.scan_line(&s);
+        let first = scanner.scan_line_first(&s);
+        match (all.first(), first) {
+            (None, None) => {} // OK
+            (Some(a), Some(f)) => {
+                prop_assert!(f.range.start <= a.range.start);
+            }
+            (Some(_), None) => {
+                prop_assert!(false, "scan_line found matches but scan_line_first didn't");
+            }
+            (None, Some(_)) => {
+                prop_assert!(false, "scan_line_first found match but scan_line didn't");
+            }
+        }
+    }
+}
+
+// --- Scanner consistency: dispatch finders ---
+// For each dispatchable finder, verify try_at-based scanning
+// produces the same matches as find()-based scanning.
+
+fn check_dispatch_consistency(finder: Box<dyn Finder>, input: &str) {
+    let old = old_style_find_all(finder.as_ref(), input);
+    let scanner = Scanner::new(vec![finder]);
+    let new: Vec<Range<usize>> = scanner
+        .scan_line(input)
+        .into_iter()
+        .map(|m| m.range)
+        .collect();
+    let old_texts = collect_texts(input, &old);
+    let new_texts = collect_texts(input, &new);
+    assert_eq!(old_texts, new_texts, "Mismatch on input: {:?}", input);
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(1000))]
+
+    #[test]
+    fn hash_dispatch_consistent(s in "[a-f0-9 A-F]{0,200}") {
+        check_dispatch_consistency(Box::new(squeeze::hash::Hash::default()), &s);
+    }
+
+    #[test]
+    fn env_dispatch_consistent(s in "[a-zA-Z0-9_$ {}]{0,100}") {
+        check_dispatch_consistency(Box::new(squeeze::env::Env::default()), &s);
+    }
+
+    #[test]
+    fn color_dispatch_consistent(s in "[#a-fA-F0-9rgbhslRGBHSL() ,%.]{0,100}") {
+        check_dispatch_consistency(Box::new(squeeze::color::Color::default()), &s);
+    }
+
+    #[test]
+    fn json_dispatch_consistent(s in r#"[{}\[\]"a-z:, 0-9\\]{0,100}"#) {
+        check_dispatch_consistency(Box::new(squeeze::json::Json::default()), &s);
+    }
+
+    #[test]
+    fn uuid_dispatch_consistent(s in "[a-f0-9\\- ]{0,100}") {
+        check_dispatch_consistency(Box::new(squeeze::uuid::Uuid::default()), &s);
+    }
+
+    #[test]
+    fn mac_dispatch_consistent(s in "[a-fA-F0-9:.\\- ]{0,60}") {
+        check_dispatch_consistency(Box::new(squeeze::mac::Mac::default()), &s);
+    }
+
+    #[test]
+    fn ip_dispatch_consistent(s in "[0-9.:a-f\\[\\] ]{0,80}") {
+        check_dispatch_consistency(Box::new(squeeze::ip::Ip::default()), &s);
+    }
+
+    #[test]
+    fn datetime_dispatch_consistent(s in "[0-9\\-T:Z+. ]{0,60}") {
+        check_dispatch_consistency(Box::new(squeeze::datetime::Datetime::default()), &s);
+    }
+
+    #[test]
+    fn semver_dispatch_consistent(s in "[0-9.vV\\-+a-z ]{0,60}") {
+        check_dispatch_consistency(Box::new(squeeze::semver::Semver::default()), &s);
+    }
+
+    #[test]
+    fn jwt_dispatch_consistent(s in "[a-zA-Z0-9+/=._\\- ]{0,200}") {
+        check_dispatch_consistency(Box::new(squeeze::jwt::Jwt::default()), &s);
+    }
+
+    #[test]
+    fn cidr_dispatch_consistent(s in "[0-9.:/a-f ]{0,60}") {
+        check_dispatch_consistency(Box::new(squeeze::cidr::Cidr::default()), &s);
+    }
+
+    #[test]
+    fn path_dispatch_consistent(s in "[a-z/.~\\- :0-9 ]{0,60}") {
+        check_dispatch_consistency(Box::new(squeeze::path::Path::default()), &s);
+    }
+}
+
+// --- Fuzz: no panics with individual finders on arbitrary input ---
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(500))]
+
+    #[test]
+    fn hash_no_panic(s in "\\PC{0,200}") {
+        let finder = squeeze::hash::Hash::default();
+        let _ = finder.find(&s);
+    }
+
+    #[test]
+    fn ip_no_panic(s in "\\PC{0,200}") {
+        let finder = squeeze::ip::Ip::default();
+        let _ = finder.find(&s);
+    }
+
+    #[test]
+    fn email_no_panic(s in "\\PC{0,200}") {
+        let finder = squeeze::email::Email::default();
+        let _ = finder.find(&s);
+    }
+
+    #[test]
+    fn json_no_panic(s in "\\PC{0,200}") {
+        let finder = squeeze::json::Json::default();
+        let _ = finder.find(&s);
+    }
+
+    #[test]
+    fn uri_no_panic(s in "\\PC{0,200}") {
+        let finder = squeeze::uri::URI::default();
+        let _ = finder.find(&s);
+    }
+
+    #[test]
+    fn datetime_no_panic(s in "\\PC{0,200}") {
+        let finder = squeeze::datetime::Datetime::default();
+        let _ = finder.find(&s);
+    }
+
+    #[test]
+    fn env_no_panic(s in "\\PC{0,200}") {
+        let finder = squeeze::env::Env::default();
+        let _ = finder.find(&s);
+    }
+
+    #[test]
+    fn uuid_no_panic(s in "\\PC{0,200}") {
+        let finder = squeeze::uuid::Uuid::default();
+        let _ = finder.find(&s);
+    }
+
+    #[test]
+    fn mac_no_panic(s in "\\PC{0,200}") {
+        let finder = squeeze::mac::Mac::default();
+        let _ = finder.find(&s);
+    }
+
+    #[test]
+    fn semver_no_panic(s in "\\PC{0,200}") {
+        let finder = squeeze::semver::Semver::default();
+        let _ = finder.find(&s);
+    }
+
+    #[test]
+    fn color_no_panic(s in "\\PC{0,200}") {
+        let finder = squeeze::color::Color::default();
+        let _ = finder.find(&s);
+    }
+
+    #[test]
+    fn cidr_no_panic(s in "\\PC{0,200}") {
+        let finder = squeeze::cidr::Cidr::default();
+        let _ = finder.find(&s);
+    }
+
+    #[test]
+    fn path_no_panic(s in "\\PC{0,200}") {
+        let finder = squeeze::path::Path::default();
+        let _ = finder.find(&s);
+    }
+
+    #[test]
+    fn phone_no_panic(s in "\\PC{0,200}") {
+        let finder = squeeze::phone::Phone::default();
+        let _ = finder.find(&s);
+    }
+
+    #[test]
+    fn jwt_no_panic(s in "\\PC{0,200}") {
+        let finder = squeeze::jwt::Jwt::default();
+        let _ = finder.find(&s);
+    }
+
+    #[test]
+    fn mirror_no_panic(s in "\\PC{0,200}") {
+        let finder = squeeze::mirror::Mirror::default();
+        let _ = finder.find(&s);
+    }
+}
+
+// --- Fuzz: try_at no panics on arbitrary positions ---
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(500))]
+
+    #[test]
+    fn hash_try_at_no_panic(s in "[\\x00-\\x7f]{1,100}") {
+        let finder = squeeze::hash::Hash::default();
+        let input = s.as_bytes();
+        for pos in 0..input.len() {
+            let _ = finder.try_at(input, pos);
+        }
+    }
+
+    #[test]
+    fn ip_try_at_no_panic(s in "[\\x00-\\x7f]{1,100}") {
+        let finder = squeeze::ip::Ip::default();
+        let input = s.as_bytes();
+        for pos in 0..input.len() {
+            let _ = finder.try_at(input, pos);
+        }
+    }
+
+    #[test]
+    fn env_try_at_no_panic(s in "[\\x00-\\x7f]{1,100}") {
+        let finder = squeeze::env::Env::default();
+        let input = s.as_bytes();
+        for pos in 0..input.len() {
+            let _ = finder.try_at(input, pos);
+        }
+    }
+
+    #[test]
+    fn uuid_try_at_no_panic(s in "[\\x00-\\x7f]{1,100}") {
+        let finder = squeeze::uuid::Uuid::default();
+        let input = s.as_bytes();
+        for pos in 0..input.len() {
+            let _ = finder.try_at(input, pos);
+        }
+    }
+
+    #[test]
+    fn color_try_at_no_panic(s in "[\\x00-\\x7f]{1,100}") {
+        let finder = squeeze::color::Color::default();
+        let input = s.as_bytes();
+        for pos in 0..input.len() {
+            let _ = finder.try_at(input, pos);
+        }
+    }
+
+    #[test]
+    fn mac_try_at_no_panic(s in "[\\x00-\\x7f]{1,100}") {
+        let finder = squeeze::mac::Mac::default();
+        let input = s.as_bytes();
+        for pos in 0..input.len() {
+            let _ = finder.try_at(input, pos);
+        }
+    }
+
+    #[test]
+    fn datetime_try_at_no_panic(s in "[\\x00-\\x7f]{1,100}") {
+        let finder = squeeze::datetime::Datetime::default();
+        let input = s.as_bytes();
+        for pos in 0..input.len() {
+            let _ = finder.try_at(input, pos);
+        }
+    }
+
+    #[test]
+    fn semver_try_at_no_panic(s in "[\\x00-\\x7f]{1,100}") {
+        let finder = squeeze::semver::Semver::default();
+        let input = s.as_bytes();
+        for pos in 0..input.len() {
+            let _ = finder.try_at(input, pos);
+        }
+    }
+
+    #[test]
+    fn jwt_try_at_no_panic(s in "[\\x00-\\x7f]{1,100}") {
+        let finder = squeeze::jwt::Jwt::default();
+        let input = s.as_bytes();
+        for pos in 0..input.len() {
+            let _ = finder.try_at(input, pos);
+        }
+    }
+
+    #[test]
+    fn path_try_at_no_panic(s in "[\\x00-\\x7f]{1,100}") {
+        let finder = squeeze::path::Path::default();
+        let input = s.as_bytes();
+        for pos in 0..input.len() {
+            let _ = finder.try_at(input, pos);
+        }
+    }
+
+    #[test]
+    fn cidr_try_at_no_panic(s in "[\\x00-\\x7f]{1,100}") {
+        let finder = squeeze::cidr::Cidr::default();
+        let input = s.as_bytes();
+        for pos in 0..input.len() {
+            let _ = finder.try_at(input, pos);
+        }
+    }
+}
+
+// --- Fuzz: mixed patterns with embedded valid tokens ---
+
+fn hash_md5() -> &'static str {
+    "5d41402abc4b2a76b9719d911017c592"
+}
+
+fn sample_email() -> &'static str {
+    "user@example.com"
+}
+
+fn sample_ip() -> &'static str {
+    "192.168.1.1"
+}
+
+fn sample_uuid() -> &'static str {
+    "550e8400-e29b-41d4-a716-446655440000"
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(200))]
+
+    #[test]
+    fn scanner_with_embedded_hash(
+        prefix in "[^a-fA-F0-9]{0,20}",
+        suffix in "[^a-fA-F0-9]{0,20}"
+    ) {
+        let input = format!("{}{}{}", prefix, hash_md5(), suffix);
+        let finders: Vec<Box<dyn Finder>> = vec![Box::new(squeeze::hash::Hash::default())];
+        let scanner = Scanner::new(finders);
+        let matches = scanner.scan_line(&input);
+        prop_assert_eq!(matches.len(), 1);
+        prop_assert_eq!(&input[matches[0].range.clone()], hash_md5());
+    }
+
+    #[test]
+    fn scanner_with_embedded_email(
+        prefix in "[^a-zA-Z0-9.!#$%&'*+/=?^_`{|}~\\-]{0,20}",
+        suffix in "[ \\t\\n]{0,5}"
+    ) {
+        let input = format!("{}{}{}", prefix, sample_email(), suffix);
+        let finders: Vec<Box<dyn Finder>> = vec![Box::new(squeeze::email::Email::default())];
+        let scanner = Scanner::new(finders);
+        let matches = scanner.scan_line(&input);
+        prop_assert_eq!(matches.len(), 1);
+        prop_assert_eq!(&input[matches[0].range.clone()], sample_email());
+    }
+
+    #[test]
+    fn scanner_with_embedded_ip(
+        prefix in "[^0-9.:a-fA-F\\[\\]]{0,20}",
+        suffix in "[^0-9.:a-fA-F\\[\\]]{0,20}"
+    ) {
+        let input = format!("{}{}{}", prefix, sample_ip(), suffix);
+        let finders: Vec<Box<dyn Finder>> = vec![Box::new(squeeze::ip::Ip::default())];
+        let scanner = Scanner::new(finders);
+        let matches = scanner.scan_line(&input);
+        prop_assert_eq!(matches.len(), 1);
+        prop_assert_eq!(&input[matches[0].range.clone()], sample_ip());
+    }
+
+    #[test]
+    fn scanner_with_embedded_uuid(
+        prefix in "[^a-fA-F0-9\\-]{0,20}",
+        suffix in "[^a-fA-F0-9\\-]{0,20}"
+    ) {
+        let input = format!("{}{}{}", prefix, sample_uuid(), suffix);
+        let finders: Vec<Box<dyn Finder>> = vec![Box::new(squeeze::uuid::Uuid::default())];
+        let scanner = Scanner::new(finders);
+        let matches = scanner.scan_line(&input);
+        prop_assert_eq!(matches.len(), 1);
+        prop_assert_eq!(&input[matches[0].range.clone()], sample_uuid());
+    }
+}
+
+// --- Targeted consistency on known-good inputs ---
+
+#[test]
+fn dispatch_consistent_hash_known() {
+    let cases = [
+        "5d41402abc4b2a76b9719d911017c592",
+        "md5: 5d41402abc4b2a76b9719d911017c592 end",
+        "5d41402abc4b2a76b9719d911017c592 and 2aae6c35c94fcfb415dbe95f408b9ce91ee846ed",
+        "a5d41402abc4b2a76b9719d911017c592",
+        "",
+        "no hex here",
+        "abcdef",
+    ];
+    for input in &cases {
+        check_dispatch_consistency(Box::new(squeeze::hash::Hash::default()), input);
+    }
+}
+
+#[test]
+fn dispatch_consistent_env_known() {
+    let cases = [
+        "$HOME",
+        "${PATH}",
+        "$HOME and ${PATH}",
+        "$",
+        "$$",
+        "$123",
+        "${} foo",
+        "${HOME",
+        "",
+    ];
+    for input in &cases {
+        check_dispatch_consistency(Box::new(squeeze::env::Env::default()), input);
+    }
+}
+
+#[test]
+fn dispatch_consistent_json_known() {
+    let cases = [
+        r#"{"key": "value"}"#,
+        r#"{unclosed {"valid": true}"#,
+        r#"[1, [2, 3]]"#,
+        "{}",
+        "[]",
+        "{",
+        "",
+        r#"{"a": "}"}"#,
+    ];
+    for input in &cases {
+        check_dispatch_consistency(Box::new(squeeze::json::Json::default()), input);
+    }
+}
+
+#[test]
+fn dispatch_consistent_ip_known() {
+    let cases = [
+        "192.168.1.1",
+        "10.0.0.1 and 10.0.0.2",
+        "256.1.1.1",
+        "[::1]",
+        "2001:db8::1",
+        "",
+        "999.999.999.999",
+        "1.2.3.4.5",
+    ];
+    for input in &cases {
+        check_dispatch_consistency(Box::new(squeeze::ip::Ip::default()), input);
+    }
+}
+
+#[test]
+fn dispatch_consistent_datetime_known() {
+    let cases = [
+        "2024-01-15",
+        "2024-01-15T10:30:00Z",
+        "2024-01-15T10:30:00+05:30",
+        "2024-13-01",
+        "12024-01-15",
+        "",
+        "2024-01-155",
+    ];
+    for input in &cases {
+        check_dispatch_consistency(Box::new(squeeze::datetime::Datetime::default()), input);
+    }
+}
+
+#[test]
+fn dispatch_consistent_uuid_known() {
+    let cases = [
+        "550e8400-e29b-41d4-a716-446655440000",
+        "id: 550e8400-e29b-41d4-a716-446655440000 end",
+        "ff550e8400-e29b-41d4-a716-446655440000",
+        "550e8400-e29b-41d4-a716-446655440000ff",
+        "",
+    ];
+    for input in &cases {
+        check_dispatch_consistency(Box::new(squeeze::uuid::Uuid::default()), input);
+    }
+}
+
+#[test]
+fn dispatch_consistent_path_known() {
+    let cases = [
+        "/etc/hosts",
+        "see /etc/hosts for details",
+        "./src/main.rs",
+        "../README.md",
+        "~/.bashrc",
+        "a / b",
+        "",
+        "https://example.com/path",
+        "/var/log/syslog, /tmp/out",
+    ];
+    for input in &cases {
+        check_dispatch_consistency(Box::new(squeeze::path::Path::default()), input);
+    }
+}
+
+#[test]
+fn dispatch_consistent_semver_known() {
+    let cases = [
+        "1.0.0",
+        "v2.3.1",
+        "v1.0.0-rc.1",
+        "1.0.0+build.42",
+        "1.0",
+        "192.168.1.1",
+        "",
+        "a1.0.0",
+    ];
+    for input in &cases {
+        check_dispatch_consistency(Box::new(squeeze::semver::Semver::default()), input);
+    }
+}
+
+#[test]
+fn dispatch_consistent_color_known() {
+    let cases = [
+        "#ff00aa",
+        "#f0a",
+        "rgb(255, 0, 170)",
+        "hsla(120, 100%, 50%, 0.8)",
+        "color: #333;",
+        "#ff0000 and rgb(0, 255, 0)",
+        "",
+        "#gg",
+        "srgb(1, 2, 3)",
+    ];
+    for input in &cases {
+        check_dispatch_consistency(Box::new(squeeze::color::Color::default()), input);
+    }
+}
+
+#[test]
+fn dispatch_consistent_mac_known() {
+    let cases = [
+        "00:1A:2B:3C:4D:5E",
+        "00-1A-2B-3C-4D-5E",
+        "001A.2B3C.4D5E",
+        "ff00:1A:2B:3C:4D:5E",
+        "",
+        "00:1A:2B:3C:4D",
+    ];
+    for input in &cases {
+        check_dispatch_consistency(Box::new(squeeze::mac::Mac::default()), input);
+    }
+}
+
+#[test]
+fn dispatch_consistent_jwt_known() {
+    let jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+    let cases = [
+        jwt,
+        &format!("token: {} end", jwt),
+        &format!("x{}", jwt),
+        "abc.def.ghi",
+        "",
+    ];
+    for input in &cases {
+        check_dispatch_consistency(Box::new(squeeze::jwt::Jwt::default()), input);
+    }
+}
+
+#[test]
+fn dispatch_consistent_cidr_known() {
+    let cases = [
+        "192.168.1.0/24",
+        "10.0.0.0/8",
+        "2001:db8::/32",
+        "::1/128",
+        "192.168.1.0/33",
+        "192.168.1.1",
+        "",
+    ];
+    for input in &cases {
+        check_dispatch_consistency(Box::new(squeeze::cidr::Cidr::default()), input);
+    }
+}

--- a/squeeze/tests/integration.rs
+++ b/squeeze/tests/integration.rs
@@ -1,7 +1,7 @@
 use squeeze::{
-    cidr::Cidr, codetag::Codetag, color::Color, datetime::Datetime, email::Email, env::Env,
+    Finder, cidr::Cidr, codetag::Codetag, color::Color, datetime::Datetime, email::Email, env::Env,
     hash::Hash, ip::Ip, json::Json, jwt::Jwt, mac::Mac, mirror::Mirror, path::Path, phone::Phone,
-    semver::Semver, uri::URI, uuid::Uuid, Finder,
+    semver::Semver, uri::URI, uuid::Uuid,
 };
 
 #[test]

--- a/squeeze/tests/multibyte.rs
+++ b/squeeze/tests/multibyte.rs
@@ -231,10 +231,7 @@ fn scanner_multibyte_multi_finder() {
     ];
     let input = "🌐192.168.1.1 📧user@example.com 📂$HOME";
     let results = scan(finders, input);
-    assert_eq!(
-        results,
-        vec!["192.168.1.1", "user@example.com", "$HOME"]
-    );
+    assert_eq!(results, vec!["192.168.1.1", "user@example.com", "$HOME"]);
 }
 
 #[test]
@@ -271,9 +268,7 @@ fn scanner_pure_unicode_no_panic() {
 
 #[test]
 fn scanner_many_matches_interspersed_with_unicode() {
-    let finders: Vec<Box<dyn Finder>> = vec![
-        Box::new(squeeze::hash::Hash::default()),
-    ];
+    let finders: Vec<Box<dyn Finder>> = vec![Box::new(squeeze::hash::Hash::default())];
     let hash = "5d41402abc4b2a76b9719d911017c592";
     let input = format!("🔑{}🔑{}🔑{}", hash, hash, hash);
     let results = scan(finders, &input);
@@ -285,9 +280,7 @@ fn scanner_many_matches_interspersed_with_unicode() {
 
 #[test]
 fn scanner_mirror_preserves_unicode() {
-    let finders: Vec<Box<dyn Finder>> = vec![
-        Box::new(squeeze::mirror::Mirror::default()),
-    ];
+    let finders: Vec<Box<dyn Finder>> = vec![Box::new(squeeze::mirror::Mirror::default())];
     let input = "日本語 🎉 café";
     let results = scan(finders, input);
     assert_eq!(results, vec!["日本語 🎉 café"]);
@@ -309,14 +302,14 @@ fn finders_dont_match_utf8_continuation_bytes_as_hex() {
 fn uuid_not_found_in_pure_unicode() {
     let finder = squeeze::uuid::Uuid::default();
     let input = "文字列データ漢字テスト";
-    assert!(finder.find(&input).is_none());
+    assert!(finder.find(input).is_none());
 }
 
 #[test]
 fn ip_not_found_in_pure_unicode() {
     let finder = squeeze::ip::Ip::default();
     let input = "日本語テキストのみ";
-    assert!(finder.find(&input).is_none());
+    assert!(finder.find(input).is_none());
 }
 
 // --- Mixed byte length contexts ---

--- a/squeeze/tests/multibyte.rs
+++ b/squeeze/tests/multibyte.rs
@@ -1,5 +1,5 @@
-use squeeze::scanner::Scanner;
 use squeeze::Finder;
+use squeeze::scanner::Scanner;
 
 fn scan(finders: Vec<Box<dyn Finder>>, input: &str) -> Vec<String> {
     let scanner = Scanner::new(finders);

--- a/squeeze/tests/multibyte.rs
+++ b/squeeze/tests/multibyte.rs
@@ -1,0 +1,393 @@
+use squeeze::scanner::Scanner;
+use squeeze::Finder;
+
+fn scan(finders: Vec<Box<dyn Finder>>, input: &str) -> Vec<String> {
+    let scanner = Scanner::new(finders);
+    scanner
+        .scan_line(input)
+        .into_iter()
+        .map(|m| input[m.range].to_string())
+        .collect()
+}
+
+fn find_all(finder: &dyn Finder, input: &str) -> Vec<String> {
+    let mut results = Vec::new();
+    let mut idx = 0;
+    while idx < input.len() {
+        if let Some(range) = finder.find(&input[idx..]) {
+            results.push(input[idx + range.start..idx + range.end].to_string());
+            idx += range.end;
+        } else {
+            break;
+        }
+    }
+    results
+}
+
+// --- Hash with multi-byte context ---
+
+#[test]
+fn hash_surrounded_by_emoji() {
+    let finder = squeeze::hash::Hash::default();
+    let input = "🔑5d41402abc4b2a76b9719d911017c592🔑";
+    let results = find_all(&finder, input);
+    assert_eq!(results, vec!["5d41402abc4b2a76b9719d911017c592"]);
+}
+
+#[test]
+fn hash_between_cjk() {
+    let finder = squeeze::hash::Hash::default();
+    let input = "ハッシュ5d41402abc4b2a76b9719d911017c592確認";
+    let results = find_all(&finder, input);
+    assert_eq!(results, vec!["5d41402abc4b2a76b9719d911017c592"]);
+}
+
+#[test]
+fn hash_after_accented_chars() {
+    let finder = squeeze::hash::Hash::default();
+    let input = "résumé: 5d41402abc4b2a76b9719d911017c592";
+    let results = find_all(&finder, input);
+    assert_eq!(results, vec!["5d41402abc4b2a76b9719d911017c592"]);
+}
+
+// --- IP with multi-byte context ---
+
+#[test]
+fn ip_in_japanese_text() {
+    let finder = squeeze::ip::Ip::default();
+    let input = "サーバー 192.168.1.1 接続";
+    let results = find_all(&finder, input);
+    assert_eq!(results, vec!["192.168.1.1"]);
+}
+
+#[test]
+fn ip_with_emoji_separators() {
+    let finder = squeeze::ip::Ip::default();
+    let input = "🖥️10.0.0.1🌐10.0.0.2";
+    let results = find_all(&finder, input);
+    assert_eq!(results, vec!["10.0.0.1", "10.0.0.2"]);
+}
+
+// --- Email with multi-byte context ---
+
+#[test]
+fn email_in_chinese_text() {
+    let finder = squeeze::email::Email::default();
+    let input = "联系我们 user@example.com 获取帮助";
+    let results = find_all(&finder, input);
+    assert_eq!(results, vec!["user@example.com"]);
+}
+
+#[test]
+fn email_with_emoji_around() {
+    let finder = squeeze::email::Email::default();
+    let input = "📧user@example.com📧";
+    let results = find_all(&finder, input);
+    assert_eq!(results, vec!["user@example.com"]);
+}
+
+#[test]
+fn email_unicode_local_part_rejected() {
+    let finder = squeeze::email::Email::default();
+    assert!(finder.find("ñ@example.com").is_none());
+}
+
+#[test]
+fn email_unicode_domain_rejected() {
+    let finder = squeeze::email::Email::default();
+    assert!(finder.find("user@例え.com").is_none());
+}
+
+// --- JSON with multi-byte content ---
+
+#[test]
+fn json_with_unicode_values() {
+    let finder = squeeze::json::Json::default();
+    let input = r#"{"名前": "太郎", "emoji": "🎉"}"#;
+    let results = find_all(&finder, input);
+    assert_eq!(results, vec![r#"{"名前": "太郎", "emoji": "🎉"}"#]);
+}
+
+#[test]
+fn json_between_emoji() {
+    let finder = squeeze::json::Json::default();
+    let input = r#"🎯{"key": "value"}🎯"#;
+    let results = find_all(&finder, input);
+    assert_eq!(results, vec![r#"{"key": "value"}"#]);
+}
+
+#[test]
+fn json_with_escaped_unicode() {
+    let finder = squeeze::json::Json::default();
+    let input = r#"{"text": "é"}"#;
+    let results = find_all(&finder, input);
+    assert_eq!(results, vec![r#"{"text": "é"}"#]);
+}
+
+// --- Path with multi-byte context ---
+
+#[test]
+fn path_in_japanese_text() {
+    let finder = squeeze::path::Path::default();
+    let input = "ファイル ./src/main.rs を編集";
+    let results = find_all(&finder, input);
+    assert_eq!(results, vec!["./src/main.rs"]);
+}
+
+#[test]
+fn path_with_unicode_segment() {
+    let finder = squeeze::path::Path::default();
+    let input = "/home/ユーザー/ドキュメント";
+    let results = find_all(&finder, input);
+    assert_eq!(results, vec!["/home/ユーザー/ドキュメント"]);
+}
+
+// --- Env with multi-byte context ---
+
+#[test]
+fn env_in_japanese_text() {
+    let finder = squeeze::env::Env::default();
+    let input = "ホーム $HOME ディレクトリ";
+    let results = find_all(&finder, input);
+    assert_eq!(results, vec!["$HOME"]);
+}
+
+#[test]
+fn env_after_emoji() {
+    let finder = squeeze::env::Env::default();
+    let input = "📂$HOME";
+    let results = find_all(&finder, input);
+    assert_eq!(results, vec!["$HOME"]);
+}
+
+// --- Datetime with multi-byte context ---
+
+#[test]
+fn datetime_in_cjk() {
+    let finder = squeeze::datetime::Datetime::default();
+    let input = "日付：2024-01-15T10:30:00Z 確認";
+    let results = find_all(&finder, input);
+    assert_eq!(results, vec!["2024-01-15T10:30:00Z"]);
+}
+
+// --- Color with multi-byte ---
+
+#[test]
+fn color_hex_after_emoji() {
+    let finder = squeeze::color::Color::default();
+    let input = "🎨#ff00aa";
+    let results = find_all(&finder, input);
+    assert_eq!(results, vec!["#ff00aa"]);
+}
+
+// --- UUID with multi-byte ---
+
+#[test]
+fn uuid_in_japanese() {
+    let finder = squeeze::uuid::Uuid::default();
+    let input = "識別子 550e8400-e29b-41d4-a716-446655440000 です";
+    let results = find_all(&finder, input);
+    assert_eq!(results, vec!["550e8400-e29b-41d4-a716-446655440000"]);
+}
+
+// --- MAC with multi-byte ---
+
+#[test]
+fn mac_after_emoji() {
+    let finder = squeeze::mac::Mac::default();
+    let input = "🔌00:1A:2B:3C:4D:5E";
+    let results = find_all(&finder, input);
+    assert_eq!(results, vec!["00:1A:2B:3C:4D:5E"]);
+}
+
+// --- Semver with multi-byte ---
+
+#[test]
+fn semver_in_unicode_text() {
+    let finder = squeeze::semver::Semver::default();
+    let input = "バージョン v1.2.3 リリース";
+    let results = find_all(&finder, input);
+    assert_eq!(results, vec!["v1.2.3"]);
+}
+
+// --- CIDR with multi-byte ---
+
+#[test]
+fn cidr_in_cjk() {
+    let finder = squeeze::cidr::Cidr::default();
+    let input = "ネットワーク 192.168.1.0/24 設定";
+    let results = find_all(&finder, input);
+    assert_eq!(results, vec!["192.168.1.0/24"]);
+}
+
+// --- Scanner: multi-finder with multi-byte ---
+
+#[test]
+fn scanner_multibyte_multi_finder() {
+    let finders: Vec<Box<dyn Finder>> = vec![
+        Box::new(squeeze::ip::Ip::default()),
+        Box::new(squeeze::email::Email::default()),
+        Box::new(squeeze::env::Env::default()),
+    ];
+    let input = "🌐192.168.1.1 📧user@example.com 📂$HOME";
+    let results = scan(finders, input);
+    assert_eq!(
+        results,
+        vec!["192.168.1.1", "user@example.com", "$HOME"]
+    );
+}
+
+#[test]
+fn scanner_pure_unicode_no_panic() {
+    let finders: Vec<Box<dyn Finder>> = vec![
+        Box::new(squeeze::hash::Hash::default()),
+        Box::new(squeeze::email::Email::default()),
+        Box::new(squeeze::ip::Ip::default()),
+        Box::new(squeeze::json::Json::default()),
+    ];
+    let scanner = Scanner::new(finders);
+    let inputs = [
+        "日本語テキスト",
+        "🎉🎊🎈🎁",
+        "Ñoño café résumé naïve",
+        "Ελληνικά Кириллица العربية",
+        "\u{200B}\u{FEFF}\u{00AD}",
+        "🇺🇸🇬🇧🇯🇵",
+        "",
+        "\u{0000}",
+    ];
+    for input in &inputs {
+        let matches = scanner.scan_line(input);
+        for m in &matches {
+            assert!(m.range.start <= m.range.end);
+            assert!(m.range.end <= input.len());
+            assert!(input.is_char_boundary(m.range.start));
+            assert!(input.is_char_boundary(m.range.end));
+        }
+    }
+}
+
+// --- Stress: many matches in unicode-heavy text ---
+
+#[test]
+fn scanner_many_matches_interspersed_with_unicode() {
+    let finders: Vec<Box<dyn Finder>> = vec![
+        Box::new(squeeze::hash::Hash::default()),
+    ];
+    let hash = "5d41402abc4b2a76b9719d911017c592";
+    let input = format!("🔑{}🔑{}🔑{}", hash, hash, hash);
+    let results = scan(finders, &input);
+    assert_eq!(results.len(), 3);
+    assert!(results.iter().all(|r| r == hash));
+}
+
+// --- Scanner with mirror and unicode ---
+
+#[test]
+fn scanner_mirror_preserves_unicode() {
+    let finders: Vec<Box<dyn Finder>> = vec![
+        Box::new(squeeze::mirror::Mirror::default()),
+    ];
+    let input = "日本語 🎉 café";
+    let results = scan(finders, input);
+    assert_eq!(results, vec!["日本語 🎉 café"]);
+}
+
+// --- UTF-8 continuation byte edge cases ---
+
+#[test]
+fn finders_dont_match_utf8_continuation_bytes_as_hex() {
+    // UTF-8 continuation bytes (0x80-0xBF) contain values like 0xAB, 0xBE
+    // that look like hex digits in isolation. Finders must not treat them as hex.
+    let finder = squeeze::hash::Hash::default();
+    // 32 copies of '你' = 32 * 3 bytes = 96 bytes, many continuation bytes
+    let input = "你".repeat(32);
+    assert!(finder.find(&input).is_none());
+}
+
+#[test]
+fn uuid_not_found_in_pure_unicode() {
+    let finder = squeeze::uuid::Uuid::default();
+    let input = "文字列データ漢字テスト";
+    assert!(finder.find(&input).is_none());
+}
+
+#[test]
+fn ip_not_found_in_pure_unicode() {
+    let finder = squeeze::ip::Ip::default();
+    let input = "日本語テキストのみ";
+    assert!(finder.find(&input).is_none());
+}
+
+// --- Mixed byte length contexts ---
+
+#[test]
+fn hash_between_2byte_chars() {
+    let finder = squeeze::hash::Hash::default();
+    // é is 2 bytes (0xC3 0xA9), ñ is 2 bytes (0xC3 0xB1)
+    let input = "é5d41402abc4b2a76b9719d911017c592ñ";
+    let results = find_all(&finder, input);
+    assert_eq!(results, vec!["5d41402abc4b2a76b9719d911017c592"]);
+}
+
+#[test]
+fn hash_between_3byte_chars() {
+    let finder = squeeze::hash::Hash::default();
+    // 中 is 3 bytes
+    let input = "中5d41402abc4b2a76b9719d911017c592中";
+    let results = find_all(&finder, input);
+    assert_eq!(results, vec!["5d41402abc4b2a76b9719d911017c592"]);
+}
+
+#[test]
+fn hash_between_4byte_chars() {
+    let finder = squeeze::hash::Hash::default();
+    // 🔑 is 4 bytes (F0 9F 94 91)
+    let input = "🔑5d41402abc4b2a76b9719d911017c592🔑";
+    let results = find_all(&finder, input);
+    assert_eq!(results, vec!["5d41402abc4b2a76b9719d911017c592"]);
+}
+
+// --- Verify scanner match ranges land on char boundaries ---
+
+#[test]
+fn scanner_ranges_on_char_boundaries_with_cjk() {
+    let finders: Vec<Box<dyn Finder>> = vec![
+        Box::new(squeeze::email::Email::default()),
+        Box::new(squeeze::hash::Hash::default()),
+        Box::new(squeeze::ip::Ip::default()),
+        Box::new(squeeze::env::Env::default()),
+        Box::new(squeeze::json::Json::default()),
+        Box::new(squeeze::datetime::Datetime::default()),
+        Box::new(squeeze::uuid::Uuid::default()),
+        Box::new(squeeze::path::Path::default()),
+    ];
+    let scanner = Scanner::new(finders);
+
+    let inputs = [
+        "日192.168.1.1本",
+        "中user@example.com文",
+        "🔑$HOME🔑",
+        r#"日{"k":"v"}本"#,
+        "日2024-01-15本",
+        "中550e8400-e29b-41d4-a716-446655440000文",
+        "日/etc/hosts本",
+    ];
+
+    for input in &inputs {
+        for m in scanner.scan_line(input) {
+            assert!(
+                input.is_char_boundary(m.range.start),
+                "start {} not char boundary in {:?}",
+                m.range.start,
+                input
+            );
+            assert!(
+                input.is_char_boundary(m.range.end),
+                "end {} not char boundary in {:?}",
+                m.range.end,
+                input
+            );
+        }
+    }
+}

--- a/squeeze/tests/uri.rs
+++ b/squeeze/tests/uri.rs
@@ -1,6 +1,6 @@
-use squeeze::{uri, Finder};
+use squeeze::{Finder, uri};
 use std::fs::File;
-use std::io::{prelude::*, BufReader};
+use std::io::{BufReader, prelude::*};
 
 #[test]
 fn it_should_succeed_to_mirror_the_fixtures_uris() {

--- a/squeeze/uri.rs
+++ b/squeeze/uri.rs
@@ -18,7 +18,6 @@
 //! ```
 
 use super::Finder;
-use memchr::memchr;
 use std::ops::Range;
 
 const SUB_DELIMS_STRICT: [bool; 256] = {
@@ -113,7 +112,7 @@ impl Finder for URI {
         while idx < input.len() {
             let start = idx;
 
-            let colon_idx = start + memchr(b':', &input[start..])?;
+            let colon_idx = start + input[start..].iter().position(|&b| b == b':')?;
             idx = colon_idx + 1;
 
             let scheme_idx = match self.rlook_scheme(&input[start..colon_idx]) {

--- a/squeeze/uri.rs
+++ b/squeeze/uri.rs
@@ -18,6 +18,7 @@
 //! ```
 
 use super::Finder;
+use memchr::memchr;
 use std::collections::HashSet;
 use std::ops::Range;
 
@@ -81,7 +82,7 @@ impl Finder for URI {
         while idx < input.len() {
             let start = idx;
 
-            let colon_idx = start + input[start..].iter().position(|&b| b == b':')?;
+            let colon_idx = start + memchr(b':', &input[start..])?;
             idx = colon_idx + 1;
 
             let scheme_idx = match self.rlook_scheme(&input[start..colon_idx]) {

--- a/squeeze/uri.rs
+++ b/squeeze/uri.rs
@@ -329,12 +329,12 @@ impl URI {
             }
 
             if last_is_colon || idx == 0 {
-                if bytes_count == 12 || double_colon_found {
-                    if let Some(i) = self.look_ipv4_address(&input[idx..]) {
-                        bytes_count += 4;
-                        idx += i;
-                        break;
-                    }
+                if (bytes_count == 12 || double_colon_found)
+                    && let Some(i) = self.look_ipv4_address(&input[idx..])
+                {
+                    bytes_count += 4;
+                    idx += i;
+                    break;
                 }
                 if let Some(i) = self.look_h16(&input[idx..]) {
                     bytes_count += 2;
@@ -356,11 +356,7 @@ impl URI {
             .take_while(|&&b| Self::is_hexdig(b))
             .take(4)
             .count();
-        if idx >= 1 {
-            Some(idx)
-        } else {
-            None
-        }
+        if idx >= 1 { Some(idx) } else { None }
     }
 
     // "v" 1*HEXDIG "." 1*( unreserved / sub-delims / ":" )

--- a/squeeze/uri.rs
+++ b/squeeze/uri.rs
@@ -19,8 +19,39 @@
 
 use super::Finder;
 use memchr::memchr;
-use std::collections::HashSet;
 use std::ops::Range;
+
+const SUB_DELIMS_STRICT: [bool; 256] = {
+    let mut table = [false; 256];
+    table[b'!' as usize] = true;
+    table[b'$' as usize] = true;
+    table[b'&' as usize] = true;
+    table[b'\'' as usize] = true;
+    table[b'(' as usize] = true;
+    table[b')' as usize] = true;
+    table[b'*' as usize] = true;
+    table[b'+' as usize] = true;
+    table[b',' as usize] = true;
+    table[b';' as usize] = true;
+    table[b'=' as usize] = true;
+    table
+};
+
+const SUB_DELIMS_LAX: [bool; 256] = {
+    let mut table = [false; 256];
+    table[b'!' as usize] = true;
+    table[b'$' as usize] = true;
+    table[b'&' as usize] = true;
+    table[b'(' as usize] = true;
+    table[b'*' as usize] = true;
+    table[b'+' as usize] = true;
+    table[b',' as usize] = true;
+    table[b';' as usize] = true;
+    table[b'=' as usize] = true;
+    table
+};
+
+const MAX_SCHEME_LEN: usize = 32;
 
 #[derive(Default, Clone, Copy)]
 struct SchemeConfig(u8);
@@ -63,7 +94,7 @@ static SCHEMES_CONFIGS: SchemeConfigs = SchemeConfigs(phf::phf_map! {
 /// Set [`URI::strict`] to `true` to strictly follow RFC 3986.
 #[derive(Default)]
 pub struct URI {
-    schemes: HashSet<String>,
+    schemes: Vec<String>,
     /// When `true`, strictly follows RFC 3986 and includes trailing `'` and `)` in URIs.
     /// When `false` (default), excludes these characters for better text extraction.
     pub strict: bool,
@@ -98,7 +129,7 @@ impl Finder for URI {
 
             // we cannot early exit as soon as we know the scheme as we need to advance idx even if the
             // uri should be discarded
-            if self.schemes.is_empty() || self.schemes.contains(scheme) {
+            if self.schemes.is_empty() || self.schemes.iter().any(|s| s == scheme) {
                 return Some(scheme_idx..idx);
             }
         }
@@ -125,16 +156,20 @@ impl URI {
     /// // Will match https:// and mailto: URIs, but not http:// or ftp://
     /// ```
     pub fn add_scheme(&mut self, s: &str) {
-        self.schemes.insert(s.to_lowercase());
+        let lower = s.to_lowercase();
+        if let Err(pos) = self.schemes.binary_search(&lower) {
+            self.schemes.insert(pos, lower);
+        }
     }
 
     // ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
     fn rlook_scheme(&self, input: &[u8]) -> Option<usize> {
+        let start = input.len().saturating_sub(MAX_SCHEME_LEN);
         let mut idx = None;
-        for (i, &c) in input.iter().enumerate().rev() {
-            if self.is_alpha(c) {
-                idx = Some(i);
-            } else if self.is_digit(c) || [b'+', b'-', b'.'].contains(&c) {
+        for (i, &c) in input[start..].iter().enumerate().rev() {
+            if Self::is_alpha(c) {
+                idx = Some(start + i);
+            } else if Self::is_digit(c) || c == b'+' || c == b'-' || c == b'.' {
                 // noop
             } else {
                 break;
@@ -319,7 +354,7 @@ impl URI {
     fn look_h16(&self, input: &[u8]) -> Option<usize> {
         let idx = input
             .iter()
-            .take_while(|&&b| self.is_hexdig(b))
+            .take_while(|&&b| Self::is_hexdig(b))
             .take(4)
             .count();
         if idx >= 1 {
@@ -339,7 +374,7 @@ impl URI {
 
         // 1*HEXDIG
         let hexdig_start = idx;
-        while idx < input.len() && self.is_hexdig(input[idx]) {
+        while idx < input.len() && Self::is_hexdig(input[idx]) {
             idx += 1;
         }
         if idx == hexdig_start {
@@ -356,7 +391,7 @@ impl URI {
         let char_start = idx;
         while idx < input.len() {
             let c = input[idx];
-            if self.is_unreserved(c) || self.is_sub_delim_strict(c) || c == b':' {
+            if Self::is_unreserved(c) || Self::is_sub_delim_strict(c) || c == b':' {
                 idx += 1;
             } else {
                 break;
@@ -369,12 +404,9 @@ impl URI {
         idx == input.len()
     }
 
-    // sub-delims for IPvFuture (always strict as per RFC)
-    fn is_sub_delim_strict(&self, c: u8) -> bool {
-        [
-            b'!', b'$', b'&', b'\'', b'(', b')', b'*', b'+', b',', b';', b'=',
-        ]
-        .contains(&c)
+    #[inline]
+    fn is_sub_delim_strict(c: u8) -> bool {
+        SUB_DELIMS_STRICT[c as usize]
     }
 
     // dec-octet "." dec-octet "." dec-octet "." dec-octet
@@ -399,32 +431,32 @@ impl URI {
         if input.len() >= 3
             && input[0] == b'2'
             && input[1] == b'5'
-            && self.is_digit_0_to_5(input[2])
+            && Self::is_digit_0_to_5(input[2])
         {
             return Some(3);
         }
 
         if input.len() >= 3
             && input[0] == b'2'
-            && self.is_digit_0_to_4(input[1])
-            && self.is_digit(input[2])
+            && Self::is_digit_0_to_4(input[1])
+            && Self::is_digit(input[2])
         {
             return Some(3);
         }
 
         if input.len() >= 3
             && input[0] == b'1'
-            && self.is_digit(input[1])
-            && self.is_digit(input[2])
+            && Self::is_digit(input[1])
+            && Self::is_digit(input[2])
         {
             return Some(3);
         }
 
-        if input.len() >= 2 && self.is_digit_1_to_9(input[0]) && self.is_digit(input[1]) {
+        if input.len() >= 2 && Self::is_digit_1_to_9(input[0]) && Self::is_digit(input[1]) {
             return Some(2);
         }
 
-        if !input.is_empty() && self.is_digit(input[0]) {
+        if !input.is_empty() && Self::is_digit(input[0]) {
             return Some(1);
         }
 
@@ -454,7 +486,7 @@ impl URI {
     fn look_label(&self, input: &[u8]) -> Option<usize> {
         let mut idx = 0;
         if idx < input.len()
-            && (self.is_alpha(input[idx]) || self.is_digit(input[idx]) || input[idx] == b'_')
+            && (Self::is_alpha(input[idx]) || Self::is_digit(input[idx]) || input[idx] == b'_')
         {
             idx += 1;
         } else {
@@ -462,8 +494,8 @@ impl URI {
         }
         while idx < input.len()
             && idx < 62
-            && (self.is_alpha(input[idx])
-                || self.is_digit(input[idx])
+            && (Self::is_alpha(input[idx])
+                || Self::is_digit(input[idx])
                 || input[idx] == b'_'
                 || input[idx] == b'-')
         {
@@ -482,7 +514,7 @@ impl URI {
 
     // *DIGIT
     fn look_port(&self, input: &[u8]) -> usize {
-        input.iter().take_while(|&&c| self.is_digit(c)).count()
+        input.iter().take_while(|&&c| Self::is_digit(c)).count()
     }
 
     fn look_question_mark_query(&self, input: &[u8]) -> Option<usize> {
@@ -496,12 +528,13 @@ impl URI {
     fn look_query(&self, input: &[u8]) -> usize {
         let mut idx = 0;
         while idx < input.len() {
-            if let Some(i) = self.look_pchar(&input[idx..]) {
-                idx += i;
+            let b = input[idx];
+            if b == b'/' || b == b'?' {
+                idx += 1;
                 continue;
             }
-            if [b'/', b'?'].contains(&input[idx]) {
-                idx += 1;
+            if let Some(i) = self.look_pchar(&input[idx..]) {
+                idx += i;
                 continue;
             }
             break;
@@ -520,12 +553,13 @@ impl URI {
     fn look_fragment(&self, input: &[u8]) -> usize {
         let mut idx = 0;
         while idx < input.len() {
-            if let Some(i) = self.look_pchar(&input[idx..]) {
-                idx += i;
+            let b = input[idx];
+            if b == b'/' || b == b'?' {
+                idx += 1;
                 continue;
             }
-            if [b'/', b'?'].contains(&input[idx]) {
-                idx += 1;
+            if let Some(i) = self.look_pchar(&input[idx..]) {
+                idx += i;
                 continue;
             }
             break;
@@ -534,26 +568,24 @@ impl URI {
     }
 
     // unreserved / pct-encoded / sub-delims / ":" / "@"
+    #[inline]
     fn look_pchar(&self, input: &[u8]) -> Option<usize> {
-        self.look_pct_encoded(input).or_else(|| {
-            if !input.is_empty()
-                && (self.is_unreserved(input[0])
-                    || self.is_sub_delim(input[0])
-                    || [b':', b'@'].contains(&input[0]))
-            {
-                Some(1)
-            } else {
-                None
+        if !input.is_empty() {
+            let b = input[0];
+            if Self::is_unreserved(b) || self.is_sub_delim(b) || b == b':' || b == b'@' {
+                return Some(1);
             }
-        })
+        }
+        self.look_pct_encoded(input)
     }
 
     // "%" HEXDIG HEXDIG
+    #[inline]
     fn look_pct_encoded(&self, input: &[u8]) -> Option<usize> {
         if input.len() >= 3
             && input[0] == b'%'
-            && self.is_hexdig(input[1])
-            && self.is_hexdig(input[2])
+            && Self::is_hexdig(input[1])
+            && Self::is_hexdig(input[2])
         {
             Some(3)
         } else {
@@ -561,6 +593,7 @@ impl URI {
         }
     }
 
+    #[inline]
     fn look_period(&self, input: &[u8]) -> Option<usize> {
         if !input.is_empty() && input[0] == b'.' {
             Some(1)
@@ -569,6 +602,7 @@ impl URI {
         }
     }
 
+    #[inline]
     fn look_left_bracket(&self, input: &[u8]) -> Option<usize> {
         if !input.is_empty() && input[0] == b'[' {
             Some(1)
@@ -577,6 +611,7 @@ impl URI {
         }
     }
 
+    #[inline]
     fn look_colon(&self, input: &[u8]) -> Option<usize> {
         if !input.is_empty() && input[0] == b':' {
             Some(1)
@@ -585,6 +620,7 @@ impl URI {
         }
     }
 
+    #[inline]
     fn look_question_mark(&self, input: &[u8]) -> Option<usize> {
         if !input.is_empty() && input[0] == b'?' {
             Some(1)
@@ -593,6 +629,7 @@ impl URI {
         }
     }
 
+    #[inline]
     fn look_sharp(&self, input: &[u8]) -> Option<usize> {
         if !input.is_empty() && input[0] == b'#' {
             Some(1)
@@ -601,6 +638,7 @@ impl URI {
         }
     }
 
+    #[inline]
     fn look_slash(&self, input: &[u8]) -> Option<usize> {
         if !input.is_empty() && input[0] == b'/' {
             Some(1)
@@ -609,6 +647,7 @@ impl URI {
         }
     }
 
+    #[inline]
     fn look_slash_slash(&self, input: &[u8]) -> Option<usize> {
         if input.len() >= 2 && input[0] == b'/' && input[1] == b'/' {
             Some(2)
@@ -621,13 +660,13 @@ impl URI {
     fn is_userinfo(&self, input: &[u8]) -> bool {
         let mut idx = 0;
         while idx < input.len() {
-            if let Some(i) = self.look_pct_encoded(&input[idx..]) {
-                idx += i;
+            let c = input[idx];
+            if Self::is_unreserved(c) || self.is_sub_delim(c) || c == b':' {
+                idx += 1;
                 continue;
             }
-            let c = input[idx];
-            if self.is_unreserved(c) || self.is_sub_delim(c) || c == b':' {
-                idx += 1;
+            if let Some(i) = self.look_pct_encoded(&input[idx..]) {
+                idx += i;
                 continue;
             }
             return false;
@@ -636,44 +675,49 @@ impl URI {
     }
 
     // ALPHA / DIGIT / "-" / "." / "_" / "~"
-    fn is_unreserved(&self, c: u8) -> bool {
-        self.is_alpha(c) || self.is_digit(c) || c == b'-' || c == b'.' || c == b'_' || c == b'~'
+    #[inline]
+    fn is_unreserved(c: u8) -> bool {
+        c.is_ascii_alphanumeric() || c == b'-' || c == b'.' || c == b'_' || c == b'~'
     }
 
     // "!" / "$" / "&" / "'" / "(" / ")" / "*" / "+" / "," / ";" / "="
+    #[inline]
     fn is_sub_delim(&self, c: u8) -> bool {
         if self.strict {
-            [
-                b'!', b'$', b'&', b'\'', b'(', b')', b'*', b'+', b',', b';', b'=',
-            ]
-            .contains(&c)
+            SUB_DELIMS_STRICT[c as usize]
         } else {
-            [b'!', b'$', b'&', b'(', b'*', b'+', b',', b';', b'='].contains(&c) // without ' and )
+            SUB_DELIMS_LAX[c as usize]
         }
     }
 
-    // ALPHA
-    fn is_alpha(&self, c: u8) -> bool {
-        c.is_ascii_lowercase() || c.is_ascii_uppercase()
+    #[inline]
+    fn is_alpha(c: u8) -> bool {
+        c.is_ascii_alphabetic()
     }
 
-    // DIGIT
-    fn is_digit(&self, c: u8) -> bool {
+    #[inline]
+    fn is_digit(c: u8) -> bool {
         c.is_ascii_digit()
     }
-    fn is_digit_1_to_9(&self, c: u8) -> bool {
+
+    #[inline]
+    fn is_digit_1_to_9(c: u8) -> bool {
         (b'1'..=b'9').contains(&c)
     }
-    fn is_digit_0_to_4(&self, c: u8) -> bool {
+
+    #[inline]
+    fn is_digit_0_to_4(c: u8) -> bool {
         (b'0'..=b'4').contains(&c)
     }
-    fn is_digit_0_to_5(&self, c: u8) -> bool {
+
+    #[inline]
+    fn is_digit_0_to_5(c: u8) -> bool {
         (b'0'..=b'5').contains(&c)
     }
 
-    // HEXDIG
-    fn is_hexdig(&self, c: u8) -> bool {
-        self.is_digit(c) || (b'a'..=b'f').contains(&c) || (b'A'..=b'F').contains(&c)
+    #[inline]
+    fn is_hexdig(c: u8) -> bool {
+        c.is_ascii_hexdigit()
     }
 }
 
@@ -1317,5 +1361,123 @@ mod tests {
         // Should match lowercase http
         let input = "http://example.com";
         assert_eq!(Some(input), finder.find(input).map(|r| &input[r]));
+    }
+
+    // --- Regression: sorted Vec scheme dedup ---
+
+    #[test]
+    fn add_scheme_deduplicates() {
+        let mut finder = URI::default();
+        finder.add_scheme("http");
+        finder.add_scheme("http");
+        finder.add_scheme("HTTP");
+        assert_eq!(finder.schemes.len(), 1);
+    }
+
+    #[test]
+    fn add_scheme_multiple_sorted() {
+        let mut finder = URI::default();
+        finder.add_scheme("https");
+        finder.add_scheme("ftp");
+        finder.add_scheme("http");
+        assert_eq!(finder.schemes, vec!["ftp", "http", "https"]);
+    }
+
+    // --- Regression: look_pchar branch order ---
+
+    #[test]
+    fn look_pchar_unreserved_chars() {
+        let finder = URI::default();
+        for input in [
+            "http://example.com/path-with-dashes_and_underscores.and.dots~tilde",
+            "http://example.com/ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+            "http://example.com/abcdefghijklmnopqrstuvwxyz",
+            "http://example.com/0123456789",
+        ] {
+            assert_eq!(
+                Some(input),
+                finder.find(input).map(|r| &input[r]),
+                "{}",
+                input
+            );
+        }
+    }
+
+    #[test]
+    fn look_pchar_pct_encoded() {
+        let finder = URI::default();
+        let input = "http://example.com/%20%2F%3A";
+        assert_eq!(Some(input), finder.find(input).map(|r| &input[r]));
+    }
+
+    #[test]
+    fn look_pchar_sub_delims() {
+        let finder = URI::default();
+        let input = "http://example.com/path!$&(*+,;=";
+        assert_eq!(Some(input), finder.find(input).map(|r| &input[r]));
+    }
+
+    // --- Regression: rlook_scheme cap ---
+
+    #[test]
+    fn rlook_scheme_very_long_prefix() {
+        let finder = URI::default();
+        let long_prefix = " ".repeat(1000);
+        let input = format!("{}http://example.com", long_prefix);
+        assert_eq!(
+            Some("http://example.com"),
+            finder.find(&input).map(|r| &input[r])
+        );
+    }
+
+    #[test]
+    fn rlook_scheme_just_within_cap() {
+        let finder = URI::default();
+        let scheme = "a".repeat(30);
+        let input = format!("{}://host", scheme);
+        assert_eq!(Some(input.as_str()), finder.find(&input).map(|r| &input[r]));
+    }
+
+    #[test]
+    fn rlook_scheme_exceeds_cap() {
+        let finder = URI::default();
+        let scheme = "a".repeat(40);
+        let input = format!("{}://host", scheme);
+        // Scheme longer than MAX_SCHEME_LEN gets truncated, but the URI
+        // is still found with a shorter scheme prefix
+        let result = finder.find(&input);
+        assert!(result.is_some());
+    }
+
+    // --- Regression: sub-delim lookup table ---
+
+    #[test]
+    fn sub_delim_strict_vs_lax() {
+        let strict = {
+            let mut f = URI::default();
+            f.strict = true;
+            f
+        };
+        let lax = URI::default();
+
+        let with_apos = "http://example.com/it's";
+        assert_eq!(
+            Some("http://example.com/it's"),
+            strict.find(with_apos).map(|r| &with_apos[r])
+        );
+        assert_eq!(
+            Some("http://example.com/it"),
+            lax.find(with_apos).map(|r| &with_apos[r])
+        );
+
+        let with_paren = "http://example.com/path)";
+        assert_eq!(
+            Some("http://example.com/path)"),
+            strict.find(with_paren).map(|r| &with_paren[r])
+        );
+        assert_eq!(
+            Some("http://example.com/path"),
+            lax.find(with_paren).map(|r| &with_paren[r])
+        );
     }
 }

--- a/squeeze/uuid.rs
+++ b/squeeze/uuid.rs
@@ -141,9 +141,11 @@ mod tests {
     #[test]
     fn find_should_reject_wrong_dash_positions() {
         let finder = Uuid::default();
-        assert!(finder
-            .find("550e840-0e29b-41d4-a716-446655440000")
-            .is_none());
+        assert!(
+            finder
+                .find("550e840-0e29b-41d4-a716-446655440000")
+                .is_none()
+        );
     }
 
     #[test]
@@ -155,25 +157,31 @@ mod tests {
     #[test]
     fn find_should_reject_non_hex() {
         let finder = Uuid::default();
-        assert!(finder
-            .find("550e8400-e29b-41d4-a716-44665544000g")
-            .is_none());
+        assert!(
+            finder
+                .find("550e8400-e29b-41d4-a716-44665544000g")
+                .is_none()
+        );
     }
 
     #[test]
     fn find_should_not_match_within_longer_hex() {
         let finder = Uuid::default();
-        assert!(finder
-            .find("ff550e8400-e29b-41d4-a716-446655440000")
-            .is_none());
+        assert!(
+            finder
+                .find("ff550e8400-e29b-41d4-a716-446655440000")
+                .is_none()
+        );
     }
 
     #[test]
     fn find_should_not_match_with_trailing_hex() {
         let finder = Uuid::default();
-        assert!(finder
-            .find("550e8400-e29b-41d4-a716-446655440000ff")
-            .is_none());
+        assert!(
+            finder
+                .find("550e8400-e29b-41d4-a716-446655440000ff")
+                .is_none()
+        );
     }
 
     #[test]
@@ -254,9 +262,11 @@ mod tests {
     #[test]
     fn find_should_reject_extra_dash_at_end() {
         let finder = Uuid::default();
-        assert!(finder
-            .find("550e8400-e29b-41d4-a716-446655440000-")
-            .is_none());
+        assert!(
+            finder
+                .find("550e8400-e29b-41d4-a716-446655440000-")
+                .is_none()
+        );
     }
 
     #[test]

--- a/squeeze/uuid.rs
+++ b/squeeze/uuid.rs
@@ -38,6 +38,31 @@ impl Finder for Uuid {
         "uuid"
     }
 
+    fn dispatchable(&self) -> bool {
+        true
+    }
+
+    fn could_start_at(&self, byte: u8) -> bool {
+        byte.is_ascii_hexdigit()
+    }
+
+    fn try_at(&self, input: &[u8], pos: usize) -> Option<Range<usize>> {
+        if !Self::is_hex(input[pos]) {
+            return None;
+        }
+        if pos > 0 && (Self::is_hex(input[pos - 1]) || input[pos - 1] == b'-') {
+            return None;
+        }
+        if !Self::check_pattern(input, pos) {
+            return None;
+        }
+        let end = pos + 36;
+        if end < input.len() && (Self::is_hex(input[end]) || input[end] == b'-') {
+            return None;
+        }
+        Some(pos..end)
+    }
+
     fn find(&self, s: &str) -> Option<Range<usize>> {
         let input = s.as_bytes();
         let mut idx = 0;
@@ -196,5 +221,56 @@ mod tests {
         let input = "00000000-0000-0000-0000-000000000000";
         let range = finder.find(input).unwrap();
         assert_eq!("00000000-0000-0000-0000-000000000000", &input[range]);
+    }
+
+    #[test]
+    fn try_at_at_start() {
+        let finder = Uuid::default();
+        let input = b"550e8400-e29b-41d4-a716-446655440000 end";
+        assert_eq!(finder.try_at(input, 0), Some(0..36));
+    }
+
+    #[test]
+    fn try_at_preceded_by_hex() {
+        let finder = Uuid::default();
+        let input = b"ff550e8400-e29b-41d4-a716-446655440000";
+        assert!(finder.try_at(input, 2).is_none());
+    }
+
+    #[test]
+    fn try_at_preceded_by_dash() {
+        let finder = Uuid::default();
+        let input = b"-550e8400-e29b-41d4-a716-446655440000";
+        assert!(finder.try_at(input, 1).is_none());
+    }
+
+    #[test]
+    fn try_at_too_short_input() {
+        let finder = Uuid::default();
+        let input = b"550e8400";
+        assert!(finder.try_at(input, 0).is_none());
+    }
+
+    #[test]
+    fn find_should_reject_extra_dash_at_end() {
+        let finder = Uuid::default();
+        assert!(finder
+            .find("550e8400-e29b-41d4-a716-446655440000-")
+            .is_none());
+    }
+
+    #[test]
+    fn find_should_handle_uuid_at_exact_end() {
+        let finder = Uuid::default();
+        let input = "x 550e8400-e29b-41d4-a716-446655440000";
+        let range = finder.find(input).unwrap();
+        assert_eq!("550e8400-e29b-41d4-a716-446655440000", &input[range]);
+    }
+
+    #[test]
+    fn find_should_handle_input_shorter_than_uuid() {
+        let finder = Uuid::default();
+        assert!(finder.find("abc").is_none());
+        assert!(finder.find("a").is_none());
     }
 }


### PR DESCRIPTION
## Summary

- **Scanner module** (`squeeze/scanner.rs`): Replaces per-finder sequential scanning with a unified single-pass architecture using a `[u32; 256]` dispatch table and per-line character-class pre-scan filtering
- **Finder trait extensions**: `dispatchable()`, `could_start_at()`, `try_at()` — 12 finders implement dispatch mode for positional matching; 6 finders remain in scan mode (email, uri, codetag, phone, json, mirror)
- **Fuzz & multi-byte testing**: proptest-based property tests (no-panic on arbitrary UTF-8, dispatch/find consistency, char-boundary validation), multi-byte edge cases (emoji, CJK, accented chars, continuation bytes), and per-finder try_at boundary tests
- **Rust edition 2024**: updated from edition 2021, resolver 3, MSRV bumped from 1.85 to 1.95
- **Dependency updates**: regex 1.11 → 1.12, clap 4.5 → 4.6, plus minor lockfile updates
- **CI fix**: removed `.cargo/config.toml` with `target-cpu=native` that caused SIGILL on CI runners

### Performance optimizations

- **Word-at-a-time prescan**: `align_to::<u64>` processes 8 bytes per iteration with early-exit on saturation
- **Stack-allocated dispatch state**: `[0usize; 32]` replaces `vec![0; n]` — zero heap allocations in the dispatch loop
- **Precomputed skip requirements**: `&'static [(u16, bool)]` slices per finder replace string-matching `can_skip_finder` on every line
- **Dispatch-aware `scan_line_first`**: bounded dispatch loop (stops at best scan match position), early-exit at position 0
- **`memchr`/`memchr2`** for email (`@`), URI (`:`), JSON (`{`/`[`) byte scanning — SIMD-accelerated on x86_64/aarch64
- **Lookup table** for email local-part character validation
- **Reused line buffer**: `read_line` into a single `String` instead of `BufRead::lines()` allocating per line
- **Release profile**: `panic = "abort"`, `strip = true`, plus existing `lto = "fat"`, `codegen-units = 1`
- **`sort_unstable_by`** for match ordering (avoids allocation for sort stability guarantee)
- **Bit-iteration** with `trailing_zeros` for active scan-mode finders

## Test plan
- [x] All 759 tests pass (`cargo test --all-targets`)
- [x] Proptest fuzz: no panics on arbitrary UTF-8/ASCII for all 17 finders
- [x] Proptest fuzz: dispatch consistency (try_at matches find) for all 12 dispatch finders
- [x] Multi-byte: matches between 2/3/4-byte UTF-8 chars land on char boundaries
- [x] CLI e2e: `--first`, multi-finder, position-ordered output verified
- [x] `cargo fmt --check`, `cargo clippy --deny warnings`, `cargo doc` all pass
- [x] Cross-platform CI: ubuntu, macos, windows all green
- [x] Rust edition 2024 formatting and let-chains clippy fixes verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)