### PR TITLE
fix(ci): use array chunks in scanner prescan

### DIFF
--- a/squeeze/scanner.rs
+++ b/squeeze/scanner.rs
@@ -83,8 +83,7 @@ static BYTE_CLASSES: [u16; 256] = build_byte_class_table();
 #[inline]
 fn prescan(input: &[u8]) -> u16 {
     let mut classes = 0u16;
-    let chunks = input.chunks_exact(8);
-    let remainder = chunks.remainder();
+    let (chunks, remainder) = input.as_chunks::<8>();
     for chunk in chunks {
         classes |= BYTE_CLASSES[chunk[0] as usize]
             | BYTE_CLASSES[chunk[1] as usize]


### PR DESCRIPTION
## Summary

Rust 1.98 Clippy rejects the scanner prescan's constant-sized `chunks_exact` iteration, failing CI on main and dependency PRs. Use `as_chunks::<8>()` to retain the same byte classification, remainder handling, and early exit while satisfying the lint.

## Test plan

- Reproduced the original Clippy failure with Rust 1.98.1.
- Run `make check`, release build, and all-target tests with Rust 1.98.1.
- Run all-target tests with the Rust 1.95 minimum supported toolchain.
- Require the CI matrix to pass before merging.
