### PR TITLE
feat: automate cross-platform releases with mise

### DIFF
--- a/.github/scripts/release.py
+++ b/.github/scripts/release.py
@@ -1,0 +1,175 @@
+"""Build release archives and publish complete, retryable GitHub releases."""
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import tarfile
+import tomllib
+from urllib.error import HTTPError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+import zipfile
+
+
+TARGETS = {
+    "x86_64-unknown-linux-gnu": "linux-amd64",
+    "aarch64-unknown-linux-gnu": "linux-arm64",
+    "x86_64-apple-darwin": "macos-amd64",
+    "aarch64-apple-darwin": "macos-arm64",
+    "x86_64-pc-windows-msvc": "windows-amd64",
+    "aarch64-pc-windows-msvc": "windows-arm64",
+}
+
+
+def api(method, path, data=None, allow_missing=False, content_type="application/json"):
+    url = path if path.startswith("https://") else "https://api.github.com" + path
+    payload = json.dumps(data).encode() if isinstance(data, dict) else data
+    request = Request(url, data=payload, method=method, headers={
+        "Authorization": "Bearer " + os.environ.get("GH_TOKEN", ""),
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "Content-Type": content_type,
+    })
+    try:
+        with urlopen(request, timeout=120) as response:
+            body = response.read()
+            return json.loads(body) if body else None
+    except HTTPError as error:
+        if allow_missing and error.code == 404:
+            return None
+        raise
+
+
+def endpoint(path):
+    return f"/repos/{os.environ['GITHUB_REPOSITORY']}/{path}"
+
+
+def output(name, value):
+    with open(os.environ["GITHUB_OUTPUT"], "a") as stream:
+        print(f"{name}={value}", file=stream)
+
+
+def crate_version(root=Path(".")):
+    versions = []
+    for crate in ("squeeze", "squeeze-cli"):
+        with (root / crate / "Cargo.toml").open("rb") as stream:
+            versions.append(tomllib.load(stream)["package"]["version"])
+    if versions[0] != versions[1]:
+        raise ValueError(f"Crate versions differ: {versions}")
+    if not re.fullmatch(r"\d+\.\d+\.\d+", versions[0]):
+        raise ValueError("Automatic releases require a stable major.minor.patch version")
+    return versions[0]
+
+
+def validate_tag(version, ref_type, ref_name):
+    tag = "v" + version
+    if ref_type == "tag" and ref_name != tag:
+        raise ValueError(f"Tag {ref_name} does not match crate version {version}")
+    if ref_type != "tag" and ref_name != "main":
+        raise ValueError("Releases must run from main or a version tag")
+    return tag
+
+
+def ensure_tag(tag, sha, create):
+    ref = api("GET", endpoint(f"git/ref/tags/{tag}"), allow_missing=True)
+    if ref is None:
+        if create:
+            api("POST", endpoint("git/refs"), {"ref": f"refs/tags/{tag}", "sha": sha})
+        return
+    target = ref["object"]
+    while target["type"] == "tag":
+        target = api("GET", endpoint(f"git/tags/{target['sha']}"))["object"]
+    if target["type"] != "commit" or target["sha"] != sha:
+        raise ValueError(f"Existing tag {tag} points to a different commit")
+
+
+def prepare():
+    version = crate_version()
+    tag = validate_tag(version, os.environ.get("GITHUB_REF_TYPE", "branch"),
+                       os.environ.get("GITHUB_REF_NAME", "main"))
+    output("version", version)
+    output("tag", tag)
+    existing = api("GET", endpoint(f"releases/tags/{tag}"), allow_missing=True)
+    if existing is not None and not existing["draft"]:
+        output("should_release", "false")
+        print(f"{tag} is already published")
+        return
+    sha = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+    ensure_tag(tag, sha, create=False)
+    output("sha", sha)
+    output("should_release", "true")
+
+
+def archive_name(tag, target):
+    suffix = "zip" if "windows" in target else "tar.gz"
+    return f"squeeze-{tag}-{TARGETS[target]}.{suffix}"
+
+
+def package(tag, target, root=Path(".")):
+    binary = "squeeze.exe" if "windows" in target else "squeeze"
+    files = [(root / "target/release" / binary, binary),
+             (root / "LICENSE", "LICENSE"), (root / "readme.md", "readme.md")]
+    destination = root / "dist" / archive_name(tag, target)
+    destination.parent.mkdir(exist_ok=True)
+    if "windows" in target:
+        with zipfile.ZipFile(destination, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+            for path, name in files:
+                archive.write(path, name)
+    else:
+        with tarfile.open(destination, "w:gz") as archive:
+            for path, name in files:
+                archive.add(path, arcname=name)
+    return destination
+
+
+def publish(tag, sha):
+    expected = {archive_name(tag, target) for target in TARGETS}
+    archives = sorted(path for path in Path("dist").iterdir() if path.name != "SHA256SUMS")
+    if {path.name for path in archives} != expected:
+        raise ValueError("Release requires exactly the six platform archives")
+    checksums = Path("dist/SHA256SUMS")
+    checksums.write_text("".join(
+        f"{hashlib.sha256(path.read_bytes()).hexdigest()}  {path.name}\n" for path in archives
+    ))
+    ensure_tag(tag, sha, create=True)
+    existing = api("GET", endpoint(f"releases/tags/{tag}"), allow_missing=True)
+    if existing is not None and not existing["draft"]:
+        raise ValueError(f"{tag} was published while building; refusing to replace its assets")
+    if existing is None:
+        existing = api("POST", endpoint("releases"), {
+            "tag_name": tag, "target_commitish": sha, "name": tag,
+            "draft": True, "generate_release_notes": True,
+        })
+    release_path = endpoint(f"releases/{existing['id']}")
+    assets = api("GET", release_path + "/assets?per_page=100")
+    for asset in assets:
+        api("DELETE", endpoint(f"releases/assets/{asset['id']}"))
+    upload_url = existing["upload_url"].split("{", 1)[0]
+    for path in archives + [checksums]:
+        api("POST", upload_url + "?name=" + quote(path.name), path.read_bytes(),
+            content_type="application/octet-stream")
+    # Compute Homebrew's source checksum before exposing the complete release.
+    source_url = f"https://github.com/{os.environ['GITHUB_REPOSITORY']}/archive/refs/tags/{tag}.tar.gz"
+    with urlopen(source_url, timeout=120) as response:
+        source_sha = hashlib.sha256(response.read()).hexdigest()
+    api("PATCH", release_path, {"draft": False, "make_latest": "true"})
+    output("source_sha", source_sha)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("command", choices=("prepare", "package", "publish"))
+    parser.add_argument("--tag")
+    parser.add_argument("--target", choices=TARGETS)
+    parser.add_argument("--sha")
+    args = parser.parse_args()
+    if args.command == "prepare":
+        prepare()
+    elif args.command == "package":
+        package(args.tag, args.target)
+    else:
+        publish(args.tag, args.sha)

--- a/.github/scripts/test_release.py
+++ b/.github/scripts/test_release.py
@@ -1,0 +1,124 @@
+import importlib.util
+import io
+from contextlib import chdir
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+from urllib.error import HTTPError
+
+
+spec = importlib.util.spec_from_file_location("release", Path(__file__).with_name("release.py"))
+release = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(release)
+
+
+class ReleaseTests(unittest.TestCase):
+    def setUp(self):
+        environment = patch.dict(release.os.environ, {
+            "GITHUB_REPOSITORY": "owner/repo", "GITHUB_REF_TYPE": "branch", "GITHUB_REF_NAME": "main",
+        })
+        environment.start()
+        self.addCleanup(environment.stop)
+
+    def test_only_not_found_is_missing(self):
+        for status in (401, 403, 429, 500):
+            with self.subTest(status=status):
+                error = HTTPError("https://api.github.com/test", status, "failed", {}, io.BytesIO())
+                with patch.object(release, "urlopen", side_effect=error):
+                    with self.assertRaises(HTTPError):
+                        release.api("GET", "/test", allow_missing=True)
+        error = HTTPError("https://api.github.com/test", 404, "missing", {}, io.BytesIO())
+        with patch.object(release, "urlopen", side_effect=error):
+            self.assertIsNone(release.api("GET", "/test", allow_missing=True))
+
+    def test_manifests_must_agree(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for crate, version in (("squeeze", "0.2.0"), ("squeeze-cli", "0.1.0")):
+                (root / crate).mkdir()
+                (root / crate / "Cargo.toml").write_text(f'[package]\nversion = "{version}"\n')
+            with self.assertRaisesRegex(ValueError, "versions differ"):
+                release.crate_version(root)
+
+    def test_tag_must_match_manifests(self):
+        with self.assertRaisesRegex(ValueError, "does not match"):
+            release.validate_tag("0.2.0", "tag", "v0.1.0")
+        self.assertEqual(release.validate_tag("0.2.0", "branch", "main"), "v0.2.0")
+
+    def test_arbitrary_branch_cannot_publish(self):
+        with self.assertRaisesRegex(ValueError, "main or a version tag"):
+            release.validate_tag("0.2.0", "branch", "feature")
+
+    def test_published_release_skips_without_retagging(self):
+        with patch.object(release, "crate_version", return_value="0.2.0"), patch.object(
+            release, "api", return_value={"draft": False}
+        ) as api, patch.object(release, "output") as output:
+            release.prepare()
+        api.assert_called_once()
+        output.assert_any_call("should_release", "false")
+
+    def test_existing_tag_must_reference_tested_commit(self):
+        with patch.object(release, "api", return_value={"object": {"type": "commit", "sha": "old"}}):
+            with self.assertRaisesRegex(ValueError, "different commit"):
+                release.ensure_tag("v0.2.0", "new", create=False)
+
+    def test_package_contains_binary_license_and_readme(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "target/release").mkdir(parents=True)
+            (root / "target/release/squeeze.exe").write_bytes(b"binary")
+            (root / "LICENSE").write_text("license")
+            (root / "readme.md").write_text("readme")
+            archive = release.package("v0.2.0", "aarch64-pc-windows-msvc", root)
+            with release.zipfile.ZipFile(archive) as bundle:
+                self.assertEqual(set(bundle.namelist()), {"squeeze.exe", "LICENSE", "readme.md"})
+
+    def test_incomplete_build_cannot_create_tag_or_release(self):
+        with tempfile.TemporaryDirectory() as directory, chdir(directory):
+            Path("dist").mkdir()
+            with patch.object(release, "api") as api:
+                with self.assertRaisesRegex(ValueError, "six platform archives"):
+                    release.publish("v0.2.0", "commit")
+                api.assert_not_called()
+
+    def test_failed_upload_stays_draft_and_retry_publishes_all_assets(self):
+        calls = []
+        uploaded = []
+        draft = {"id": 42, "draft": True, "upload_url": "https://uploads.github.com/assets{?name}"}
+        fail_upload = True
+
+        def api(method, path, data=None, **kwargs):
+            calls.append((method, path, data))
+            if path.endswith("git/ref/tags/v0.2.0"):
+                return {"object": {"type": "commit", "sha": "commit"}}
+            if path.endswith("releases/tags/v0.2.0"):
+                return draft
+            if path.endswith("/assets?per_page=100"):
+                return [{"id": 99, "name": "old-partial-asset"}]
+            if method == "POST" and path.startswith("https://uploads.github.com"):
+                if fail_upload:
+                    raise RuntimeError("upload failed")
+                uploaded.append(path)
+
+        with tempfile.TemporaryDirectory() as directory, chdir(directory):
+            Path("dist").mkdir()
+            for target in release.TARGETS:
+                Path("dist", release.archive_name("v0.2.0", target)).write_bytes(b"archive")
+            with patch.object(release, "api", side_effect=api), patch.object(
+                release, "urlopen", return_value=io.BytesIO(b"source archive")
+            ), patch.object(release, "output"):
+                with self.assertRaisesRegex(RuntimeError, "upload failed"):
+                    release.publish("v0.2.0", "commit")
+                self.assertFalse(any(method == "PATCH" for method, _, _ in calls))
+                fail_upload = False
+                release.publish("v0.2.0", "commit")
+            self.assertEqual(len(uploaded), 7)
+            self.assertEqual(calls[-1], ("PATCH", "/repos/owner/repo/releases/42", {
+                "draft": False, "make_latest": "true",
+            }))
+            self.assertEqual(len(Path("dist/SHA256SUMS").read_text().splitlines()), 6)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,76 +1,75 @@
+name: ci
+
 on:
   pull_request:
   push:
-    branches:
-      - main
+    branches: [main]
   schedule:
     - cron: '00 00 * * *'
 
-name: ci
+permissions:
+  contents: read
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
-
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: jdx/mise-action@v4
         with:
-          components: rustfmt, clippy
-
+          cache: false
       - uses: Swatinem/rust-cache@v2
+      - name: Test release automation
+        run: python3 -m unittest discover -s .github/scripts -p 'test_*.py'
+      - run: mise run check
+      - run: mise run release
 
-      - name: cargo fmt
-        run: cargo fmt --all -- --check
-
-      - name: cargo clippy
-        run: cargo clippy --all-targets -- --deny warnings
-
-      - name: cargo build
-        run: cargo build --release
-
-      - name: cargo test
-        run: cargo test --all-targets
-
-  # Minimum Supported Rust Version
   msrv:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
-
-      - uses: dtolnay/rust-toolchain@1.95
-        # MSRV defined in squeeze/Cargo.toml
-
+      - uses: jdx/mise-action@v4
+        with:
+          cache: false
       - uses: Swatinem/rust-cache@v2
+        with:
+          key: msrv
+      - run: mise run msrv
 
-      - name: cargo build
-        run: cargo build
-
-      - name: cargo test
-        run: cargo test --all-targets
-
-  # Cross-platform testing
   test:
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
+        include:
+          - runner: ubuntu-24.04
+            target: x86_64-unknown-linux-gnu
+          - runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+          - runner: macos-15-intel
+            target: x86_64-apple-darwin
+          - runner: macos-15
+            target: aarch64-apple-darwin
+          - runner: windows-2025
+            target: x86_64-pc-windows-msvc
+          - runner: windows-11-arm
+            target: aarch64-pc-windows-msvc
+    runs-on: ${{ matrix.runner }}
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - run: cargo test --all-targets
-
-  # Documentation
-  docs:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - name: cargo doc
-        run: |
-          cargo doc -p squeeze --no-deps --all-features
-          cargo doc -p squeeze-cli --no-deps --all-features
+      - name: Select native Rust host
         env:
-          RUSTDOCFLAGS: -D warnings
+          TARGET: ${{ matrix.target }}
+        run: rustup set default-host "$TARGET"
+      - uses: jdx/mise-action@v4
+        with:
+          cache: false
+      - uses: Swatinem/rust-cache@v2
+      - name: Verify native Rust target
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          rustc -vV | grep -Fx "host: $TARGET"
+      - run: mise run test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: jdx/mise-action@v4
         with:
+          version: 2026.8.4
           cache: false
       - uses: Swatinem/rust-cache@v2
       - name: Test release automation
@@ -30,6 +31,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: jdx/mise-action@v4
         with:
+          version: 2026.8.4
           cache: false
       - uses: Swatinem/rust-cache@v2
         with:
@@ -65,6 +67,7 @@ jobs:
         run: rustup set default-host "$TARGET"
       - uses: jdx/mise-action@v4
         with:
+          version: 2026.8.4
           cache: false
       - uses: Swatinem/rust-cache@v2
       - name: Verify native Rust target

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,64 +2,136 @@ name: release
 
 on:
   push:
-    tags:
-      - 'v*'
+    branches: [main]
+    tags: ['v*']
+  workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
+
+concurrency:
+  group: release
+  cancel-in-progress: false
 
 jobs:
-  release:
-    runs-on: ubuntu-latest
+  prepare:
+    runs-on: ubuntu-24.04
     outputs:
-      version: ${{ steps.version.outputs.version }}
-      sha: ${{ steps.sha.outputs.sha }}
+      version: ${{ steps.release.outputs.version }}
+      tag: ${{ steps.release.outputs.tag }}
+      sha: ${{ steps.release.outputs.sha }}
+      should_release: ${{ steps.release.outputs.should_release }}
     steps:
       - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-
-      - name: Get version from tag
-        id: version
-        run: |
-          # Extract version from tag (remove 'v' prefix)
-          VERSION="${GITHUB_REF_NAME#v}"
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-
-      - name: Verify version matches Cargo.toml
-        run: |
-          CARGO_VERSION=$(grep '^version' squeeze/Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
-          if [ "$CARGO_VERSION" != "${{ steps.version.outputs.version }}" ]; then
-            echo "Error: Tag version (${{ steps.version.outputs.version }}) does not match Cargo.toml version ($CARGO_VERSION)"
-            exit 1
-          fi
-
-      - name: Create GitHub release
-        run: |
-          gh release create "${{ github.ref_name }}" \
-            --title "${{ github.ref_name }}" \
-            --generate-notes
+      - name: Test release automation
+        run: python3 -m unittest discover -s .github/scripts -p 'test_*.py'
+      - name: Inspect version and existing release
+        id: release
+        run: python3 .github/scripts/release.py prepare
         env:
           GH_TOKEN: ${{ github.token }}
 
-      - name: Get archive SHA256
-        id: sha
+  build:
+    needs: prepare
+    if: needs.prepare.outputs.should_release == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            target: x86_64-unknown-linux-gnu
+          - runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+          - runner: macos-15-intel
+            target: x86_64-apple-darwin
+          - runner: macos-15
+            target: aarch64-apple-darwin
+          - runner: windows-2025
+            target: x86_64-pc-windows-msvc
+          - runner: windows-11-arm
+            target: aarch64-pc-windows-msvc
+    runs-on: ${{ matrix.runner }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.prepare.outputs.sha }}
+      - name: Select native Rust host
+        env:
+          TARGET: ${{ matrix.target }}
+        run: rustup set default-host "$TARGET"
+      - uses: jdx/mise-action@v4
+        with:
+          cache: false
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+      - name: Verify native Rust target
+        env:
+          TARGET: ${{ matrix.target }}
         run: |
-          # Wait a moment for the release assets to be available
-          sleep 5
-          SHA=$(curl -sL "https://github.com/${{ github.repository }}/archive/refs/tags/${{ github.ref_name }}.tar.gz" | sha256sum | cut -d' ' -f1)
-          echo "sha=$SHA" >> $GITHUB_OUTPUT
+          rustc -vV | grep -Fx "host: $TARGET"
+      - name: Check formatting and lints
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        run: mise run check
+      - name: Test
+        if: matrix.target != 'x86_64-unknown-linux-gnu'
+        run: mise run test
+      - name: Build release binary
+        run: mise run release
+      - name: Verify binary version
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          ./target/release/squeeze --version | grep -Fx "squeeze $VERSION"
+      - name: Package binary, license, and readme
+        env:
+          TAG: ${{ needs.prepare.outputs.tag }}
+          TARGET: ${{ matrix.target }}
+        run: python .github/scripts/release.py package --tag "$TAG" --target "$TARGET"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: squeeze-${{ matrix.target }}
+          path: dist/*
+          if-no-files-found: error
+
+  release:
+    needs: [prepare, build]
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    outputs:
+      source_sha: ${{ steps.publish.outputs.source_sha }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.prepare.outputs.sha }}
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: squeeze-*
+          path: dist
+          merge-multiple: true
+      - name: Publish complete release
+        id: publish
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.prepare.outputs.tag }}
+          SHA: ${{ needs.prepare.outputs.sha }}
+        run: python3 .github/scripts/release.py publish --tag "$TAG" --sha "$SHA"
 
   update-homebrew:
-    needs: release
-    runs-on: ubuntu-latest
+    needs: [prepare, release]
+    runs-on: ubuntu-24.04
     steps:
       - name: Update Homebrew formula
         uses: mislav/bump-homebrew-formula-action@v4
         with:
           formula-name: squeeze
           homebrew-tap: aymericbeaumet/homebrew-tap
-          tag-name: ${{ github.ref_name }}
-          download-sha256: ${{ needs.release.outputs.sha }}
+          tag-name: ${{ needs.prepare.outputs.tag }}
+          download-sha256: ${{ needs.release.outputs.source_sha }}
         env:
           COMMITTER_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,7 @@ jobs:
         run: rustup set default-host "$TARGET"
       - uses: jdx/mise-action@v4
         with:
+          version: 2026.8.4
           cache: false
       - uses: Swatinem/rust-cache@v2
       - uses: actions/setup-python@v6

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# Project workflow
+
+- Use `mise install` and `mise run check` for the pinned Rust toolchain and the
+  formatting, Clippy, tests, doctests, and documentation checks used by CI.
+- Run `mise run release` when changing build or packaging behavior and
+  `mise run msrv` when changing dependencies or the minimum supported Rust version.
+- Keep both crate versions and their entries in `Cargo.lock` synchronized.
+  A new version on `main` triggers publication; see [release details](docs/development.md).
+- CI and releases cover Linux, macOS, and Windows on both amd64 and arm64.
+  Preserve all six native targets when changing workflows.
+- After changing release automation, run `actionlint` and, with Python 3.11+,
+  `python3 -m unittest discover -s .github/scripts -p 'test_*.py'`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1053,7 +1053,7 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "squeeze"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "glob",
  "phf",
@@ -1064,7 +1064,7 @@ dependencies = [
 
 [[package]]
 name = "squeeze-cli"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "arboard",
  "assert_cmd",

--- a/Makefile
+++ b/Makefile
@@ -1,104 +1,12 @@
-.PHONY: all build release test bench lint fmt check clean doc install help
+.PHONY: all help build release test test-verbose bench lint fmt fmt-check check doc doc-check clean install watch watch-check run msrv update outdated audit
 
-# Default target
 all: check
 
-# Build targets
-build:
-	cargo build
-
-release:
-	cargo build --release
-
-# Testing
-test:
-	cargo test
-
-test-verbose:
-	cargo test -- --nocapture
-
-bench:
-	cargo bench -p squeeze --bench scanner
-
-# Linting and formatting
-lint:
-	cargo clippy --all-targets -- --deny warnings
-
-fmt:
-	cargo fmt --all
-
-fmt-check:
-	cargo fmt --all -- --check
-
-# Combined check (what CI runs)
-check: fmt-check lint test doc-check
-
-# Documentation
-doc:
-	cargo doc -p squeeze --no-deps --all-features --open
-
-doc-check:
-	RUSTDOCFLAGS="-D warnings" cargo doc -p squeeze --no-deps --all-features
-	RUSTDOCFLAGS="-D warnings" cargo doc -p squeeze-cli --no-deps --all-features
-
-# Clean build artifacts
-clean:
-	cargo clean
-
-# Install locally
-install:
-	cargo install --path squeeze-cli
-
-# Development helpers
-watch:
-	watchexec --clear --restart 'cargo test'
-
-watch-check:
-	watchexec --clear --restart 'make check'
-
-# Run the binary
-run:
-	@echo "Usage: echo 'text' | make run ARGS='--url'"
-	@echo "Example: echo 'https://example.com' | cargo run -- $(ARGS)"
-
-# MSRV check (Minimum Supported Rust Version)
-msrv:
-	cargo +1.95 build
-	cargo +1.95 test
-
-# Update dependencies
-update:
-	cargo update
-
-# Show outdated dependencies
-outdated:
-	cargo outdated
-
-# Security audit
-audit:
-	cargo audit
-
-# Help
 help:
-	@echo "Available targets:"
-	@echo "  all          - Run full check (default)"
-	@echo "  build        - Build debug binary"
-	@echo "  release      - Build release binary"
-	@echo "  test         - Run all tests"
-	@echo "  test-verbose - Run tests with output"
-	@echo "  bench        - Run scanner throughput benchmarks"
-	@echo "  lint         - Run clippy linter"
-	@echo "  fmt          - Format code"
-	@echo "  fmt-check    - Check code formatting"
-	@echo "  check        - Run fmt-check, lint, test, doc-check"
-	@echo "  doc          - Generate and open documentation"
-	@echo "  doc-check    - Check documentation builds without warnings"
-	@echo "  clean        - Remove build artifacts"
-	@echo "  install      - Install binary locally"
-	@echo "  watch        - Watch for changes and run tests"
-	@echo "  watch-check  - Watch for changes and run full check"
-	@echo "  msrv         - Test with minimum supported Rust version (1.95)"
-	@echo "  update       - Update dependencies"
-	@echo "  outdated     - Show outdated dependencies"
-	@echo "  audit        - Run security audit"
-	@echo "  help         - Show this help"
+	mise tasks
+
+build release test test-verbose bench lint fmt fmt-check check doc doc-check clean install watch watch-check msrv update outdated audit:
+	mise run $@
+
+run:
+	mise run run -- $(ARGS)

--- a/docs/development.md
+++ b/docs/development.md
@@ -16,7 +16,8 @@ dependencies, refresh `Cargo.lock` with Cargo and review the diff.
 `outdated` and `audit` tasks require the corresponding Cargo extensions.
 The Makefile forwards existing commands to mise.
 
-Mise manages Rust through rustup. Its Actions tool cache is disabled, while
+Actions pins mise 2026.8.4, whose release assets cover all six platforms.
+Verify those assets before updating the pin. Mise manages Rust through rustup. Its Actions tool cache is disabled, while
 `Swatinem/rust-cache` caches Cargo dependencies and build outputs; see the
 [mise action's Rust cache guidance](https://github.com/jdx/mise-action#rust-cache).
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,60 @@
+# Development and releases
+
+## Tooling
+
+`mise.toml` pins Rust 1.96.0 with rustfmt and Clippy. Run `mise trust`, then
+`mise install`. The minimum supported Rust version remains 1.95; `mise run msrv`
+installs and tests that toolchain independently of the development pin.
+
+`mise run check` runs formatting, Clippy with warnings denied, all workspace
+test targets, doctests, and documentation with warnings denied. `mise run release`
+builds the optimized CLI. Cargo tasks use `--locked` so CI and release builds
+use the committed dependency resolution. After changing crate versions or
+dependencies, refresh `Cargo.lock` with Cargo and review the diff.
+
+`mise run watch` and `mise run watch-check` use mise's watcher. The optional
+`outdated` and `audit` tasks require the corresponding Cargo extensions.
+The Makefile forwards existing commands to mise.
+
+Mise manages Rust through rustup. Its Actions tool cache is disabled, while
+`Swatinem/rust-cache` caches Cargo dependencies and build outputs; see the
+[mise action's Rust cache guidance](https://github.com/jdx/mise-action#rust-cache).
+
+## Releases
+
+To release, bump the versions in both `squeeze/Cargo.toml` and
+`squeeze-cli/Cargo.toml`, refresh `Cargo.lock`, and merge to `main`.
+The release workflow automatically builds and publishes the corresponding
+`v<version>` tag when that version has no published release. Ordinary pushes
+with an already published version do not rebuild release artifacts.
+Tag pushes and manual workflow dispatch also support release retries.
+
+Each release is tested and built on six native
+[GitHub runners](https://docs.github.com/en/actions/reference/runners/github-hosted-runners):
+
+| Platform | Architecture | Rust target | Runner |
+| --- | --- | --- | --- |
+| Linux | amd64 | `x86_64-unknown-linux-gnu` | `ubuntu-24.04` |
+| Linux | arm64 | `aarch64-unknown-linux-gnu` | `ubuntu-24.04-arm` |
+| macOS | amd64 | `x86_64-apple-darwin` | `macos-15-intel` |
+| macOS | arm64 | `aarch64-apple-darwin` | `macos-15` |
+| Windows | amd64 | `x86_64-pc-windows-msvc` | `windows-2025` |
+| Windows | arm64 | `aarch64-pc-windows-msvc` | `windows-11-arm` |
+
+Linux and macOS archives use `.tar.gz`; Windows archives use `.zip`. Each
+contains the CLI, README, and license. For example, the Windows ARM64 archive
+is `squeeze-v0.2.0-windows-arm64.zip`. `SHA256SUMS` accompanies the archives.
+Linux binaries target glibc and are built on Ubuntu 24.04.
+
+Publication waits for every build and test to pass. Assets are uploaded to a
+draft before the release becomes public, and retries can resume an unpublished
+release. The workflow uses the repository's `GITHUB_TOKEN` with `contents: write`.
+The existing Homebrew tap update runs after publication and requires
+`HOMEBREW_TAP_TOKEN` with write access to `aymericbeaumet/homebrew-tap`.
+
+Release helpers use Python 3.11+ and the standard library. Run their tests with
+`python3 -m unittest discover -s .github/scripts -p 'test_*.py'` and validate
+workflow changes with `actionlint`. If publication fails after creating a tag,
+rerun the failed workflow at its original commit or dispatch it on that tag.
+An existing tag pointing at another commit is rejected. If only the Homebrew
+update fails, rerun that failed job after fixing the tap token or permissions.

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,95 @@
+[tools]
+rust = { version = "1.96.0", profile = "minimal", components = [
+  "clippy",
+  "rustfmt",
+] }
+
+[tasks.build]
+description = "Build the workspace"
+run = "cargo build --workspace --locked"
+
+[tasks.release]
+description = "Build the optimized CLI"
+run = "cargo build --release --locked -p squeeze-cli"
+
+[tasks.test]
+description = "Run workspace tests and doctests"
+run = [
+  "cargo test --workspace --all-targets --locked",
+  "cargo test --workspace --doc --locked",
+]
+
+[tasks.test-verbose]
+run = "cargo test --workspace --locked -- --nocapture"
+
+[tasks.bench]
+description = "Benchmark scanner throughput"
+run = "cargo bench --locked -p squeeze --bench scanner"
+
+[tasks.lint]
+description = "Lint all targets"
+run = "cargo clippy --workspace --all-targets --locked -- --deny warnings"
+
+[tasks.fmt]
+description = "Format Rust code"
+run = "cargo fmt --all"
+
+[tasks.fmt-check]
+description = "Check Rust formatting"
+run = "cargo fmt --all -- --check"
+
+[tasks.doc]
+description = "Build and open documentation"
+run = "cargo doc -p squeeze --locked --no-deps --all-features --open"
+
+[tasks.doc-check]
+description = "Check documentation without warnings"
+env.RUSTDOCFLAGS = "-D warnings"
+run = [
+  "cargo doc -p squeeze --locked --no-deps --all-features",
+  "cargo doc -p squeeze-cli --locked --no-deps --all-features",
+]
+
+[tasks.check]
+description = "Run formatting, lint, tests, and documentation checks"
+run = [
+  { task = "fmt-check" },
+  { task = "lint" },
+  { task = "test" },
+  { task = "doc-check" },
+]
+
+[tasks.clean]
+run = "cargo clean"
+
+[tasks.install]
+description = "Install the CLI locally"
+run = "cargo install --locked --path squeeze-cli"
+
+[tasks.msrv]
+description = "Build and test with the minimum supported Rust version"
+tools.rust = "1.95.0"
+run = [
+  "cargo build --workspace --locked",
+  "cargo test --workspace --all-targets --locked",
+  "cargo test --workspace --doc --locked",
+]
+
+[tasks.watch]
+run = "mise watch test"
+
+[tasks.watch-check]
+run = "mise watch check"
+
+[tasks.update]
+run = "cargo update"
+
+[tasks.outdated]
+run = "cargo outdated"
+
+[tasks.audit]
+run = "cargo audit"
+
+[tasks.run]
+description = "Run the CLI (pass options after --)"
+run = "cargo run --locked -p squeeze-cli --"

--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,13 @@ the install and getting started instructions.
 
 ## Install
 
+### Prebuilt binaries
+
+Download an archive from [GitHub Releases](https://github.com/aymericbeaumet/squeeze/releases/latest)
+for Linux, macOS, or Windows and your architecture (`amd64` or `arm64`). Extract
+it and place `squeeze` (`squeeze.exe` on Windows) on your `PATH`. Each release
+includes SHA-256 checksums for the archives.
+
 ### Using Homebrew (macOS/Linux)
 
 ```shell
@@ -179,15 +186,25 @@ urls() { fc -rl 1 | squeeze --url | sort -u; }
 
 ## Development
 
-### Run binary
+Install [mise](https://mise.jdx.dev/getting-started.html), then set up the pinned
+Rust toolchain and run the same checks as CI:
 
 ```shell
-echo 'http://localhost' | cargo run -- --url
+mise trust
+mise install
+mise run check
 ```
 
-### Run tests
+Common tasks:
 
 ```shell
-cargo test
-watchexec --clear --restart 'cargo test'
+mise run build
+mise run release
+mise run test
+mise run msrv
+echo 'http://localhost' | mise run run -- --url
 ```
+
+Run `mise tasks` for the full list. Existing Make targets delegate to mise.
+See [development and releases](docs/development.md) for tooling and the
+automatic release process.

--- a/squeeze-cli/Cargo.toml
+++ b/squeeze-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "squeeze-cli"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Aymeric Beaumet <hi@aymericbeaumet.com>"]
 edition = "2024"
 rust-version = "1.95"

--- a/squeeze/Cargo.toml
+++ b/squeeze/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "squeeze"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Aymeric Beaumet <hi@aymericbeaumet.com>"]
 edition = "2024"
 rust-version = "1.95"


### PR DESCRIPTION
## Summary

A version bump merged to main now publishes a complete GitHub release automatically. Build and test native Linux, macOS, and Windows binaries for amd64 and arm64, upload archives and SHA-256 checksums to a draft, then publish after all builds pass. Existing releases are skipped, failed uploads can be retried, and the Homebrew update remains in place.

Pin mise 2026.8.4 and Rust, share local/CI tasks, retain the Rust 1.95 compatibility check, and bump both crates to 0.2.0.

## Test plan

- Passed mise check, release build, and MSRV tests locally.
- Passed nine release-helper tests, including failed-upload retries and incomplete-artifact rejection.
- Validated the changed workflows with actionlint and the mise task configuration.
- Extracted the native macOS arm64 archive and verified CLI version and URL extraction.
- All eight GitHub CI checks passed, including all six native OS/architecture combinations.
