### PR TITLE
fix: set Homebrew release commit message

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,6 +130,7 @@ jobs:
       - name: Update Homebrew formula
         uses: mislav/bump-homebrew-formula-action@v4
         with:
+          commit-message: 'chore: update {{formulaName}} to {{version}}'
           formula-name: squeeze
           homebrew-tap: aymericbeaumet/homebrew-tap
           tag-name: ${{ needs.prepare.outputs.tag }}


### PR DESCRIPTION
## Summary
Set an explicit Conventional Commit message for Homebrew formula updates so release commits contain only the formula name and version.

## Test plan
- `actionlint .github/workflows/release.yml`
- Release helper suite: all 9 tests passed.
